### PR TITLE
chore: add version info in logs

### DIFF
--- a/cmd/app/manager.go
+++ b/cmd/app/manager.go
@@ -82,6 +82,7 @@ func NewKedaKaitoScalerCommand() *cobra.Command {
 		Version: injections.VersionInfo(),
 		Run: func(cmd *cobra.Command, args []string) {
 			cliflag.PrintFlags(cmd.Flags())
+			klog.V(2).Infof("version: %s", injections.VersionInfo())
 
 			if err := Run(opts); err != nil {
 				klog.Fatalf("run keda-kaito-scaler failed, %v", err)


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
chore: add version info in logs

```
I1113 07:33:49.044078       1 manager.go:95] version: v0.2.0 (Git Commit: ae65cab, Build Date: 2025-11-13T07:31:13Z, Go Version: go1.24.10)
```

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: