### PR TITLE
fix: metrics collecting

### DIFF
--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -301,7 +301,7 @@ func parseScalerMetadata(sor *externalscaler.ScaledObjectRef, metricName string)
 func (e *kaitoScaler) getPodMetric(_ context.Context, pod *corev1.Pod, scalerConfig *ScalerConfig) (int64, error) {
 	var transport *http.Transport
 	if scalerConfig.MetricProtocol == "https" {
-		transport = e.httpTransport
+		transport = e.tlsTransport
 	} else {
 		transport = e.httpTransport
 	}
@@ -311,7 +311,7 @@ func (e *kaitoScaler) getPodMetric(_ context.Context, pod *corev1.Pod, scalerCon
 		Timeout:   scalerConfig.ScrapeTimeout,
 	}
 
-	metricURL := fmt.Sprintf("http://%s:%s%s", pod.Status.PodIP, scalerConfig.MetricPort, scalerConfig.MetricPath)
+	metricURL := fmt.Sprintf("%s://%s:%s%s", scalerConfig.MetricProtocol, pod.Status.PodIP, scalerConfig.MetricPort, scalerConfig.MetricPath)
 	klog.V(6).Infof("scraping metrics from pod %s/%s: %s", pod.Namespace, pod.Name, metricURL)
 	resp, err := httpClient.Get(metricURL)
 	if err != nil {

--- a/pkg/webhooks/scaledobject/scaled_object_default.go
+++ b/pkg/webhooks/scaledobject/scaled_object_default.go
@@ -147,7 +147,7 @@ func configureKedaKaitoScalerTrigger(obj *v1alpha1.ScaledObject, triggerIndex in
 	}
 
 	if protocol, ok := kaitoScalerTrigger.Metadata[scaler.MetricProtocolInMetadata]; !ok || len(protocol) == 0 {
-		kaitoScalerTrigger.Metadata[scaler.MetricProtocolInMetadata] = "https"
+		kaitoScalerTrigger.Metadata[scaler.MetricProtocolInMetadata] = "http"
 	}
 
 	if port, ok := kaitoScalerTrigger.Metadata[scaler.MetricPortInMetadata]; !ok || len(port) == 0 {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
fix: metrics collecting
 - fix InferenceSet listing method
 - pod metrics collecting only supports http
 - vllm:num_requests_waiting metrics is float type, there is parsing error
 - add more logs for troubleshooting

<details>

```
# curl http://127.0.0.1:5000/metrics | grep num_requests
100 22604  100 2# HELP vllm:num_requests_running Number of requests currently running on GPU.
2# TYPE vllm:num_requests_running gauge
6vllm:num_requests_running{model_name="phi-2"} 0.0
0# HELP vllm:num_requests_waiting Number of requests waiting to be processed.
4# TYPE vllm:num_requests_waiting gauge
 vllm:num_requests_waiting{model_name="phi-2"} 0.0

# k describe scaledobject
Name:         phi-2
Namespace:    default
Labels:       scaledobject.keda.sh/name=phi-2
Annotations:  scaledobject.kaito.sh/managed-by: keda-kaito-scaler
API Version:  keda.sh/v1alpha1
Kind:         ScaledObject
Metadata:
  Creation Timestamp:  2025-11-13T13:37:57Z
  Finalizers:
    finalizer.keda.sh
  Generation:  1
  Managed Fields:
    API Version:  keda.sh/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:annotations:
          .:
          f:scaledobject.kaito.sh/managed-by:
        f:ownerReferences:
          .:
          k:{"uid":"8e3ba2ec-6134-4673-a346-ef84b16661d6"}:
      f:spec:
        .:
        f:maxReplicaCount:
        f:minReplicaCount:
        f:scaleTargetRef:
          .:
          f:apiVersion:
          f:kind:
          f:name:
        f:triggers:
    Manager:      keda-kaito-scaler
    Operation:    Update
    Time:         2025-11-13T13:37:57Z
    API Version:  keda.sh/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:metadata:
        f:finalizers:
          .:
          v:"finalizer.keda.sh":
        f:labels:
          .:
          f:scaledobject.keda.sh/name:
    Manager:      keda
    Operation:    Update
    Time:         2025-11-13T13:37:59Z
    API Version:  keda.sh/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:status:
        .:
        f:authenticationsTypes:
        f:conditions:
        f:externalMetricNames:
        f:hpaName:
        f:lastActiveTime:
        f:originalReplicaCount:
        f:scaleTargetGVKR:
          .:
          f:group:
          f:kind:
          f:resource:
          f:version:
        f:scaleTargetKind:
        f:triggersTypes:
    Manager:      keda
    Operation:    Update
    Subresource:  status
    Time:         2025-11-14T03:14:29Z
  Owner References:
    API Version:           kaito.sh/v1alpha1
    Block Owner Deletion:  true
    Controller:            true
    Kind:                  InferenceSet
    Name:                  phi-2
    UID:                   8e3ba2ec-6134-4673-a346-ef84b16661d6
  Resource Version:        29861872
  UID:                     2ed84b75-4a3e-411c-967a-611bb909fbb9
Spec:
  Advanced:
    Horizontal Pod Autoscaler Config:
      Behavior:
        Scale Down:
          Policies:
            Period Seconds:              600
            Type:                        Pods
            Value:                       1
          Select Policy:                 Max
          Stabilization Window Seconds:  300
          Tolerance:                     500m
        Scale Up:
          Policies:
            Period Seconds:              300
            Type:                        Pods
            Value:                       1
          Select Policy:                 Max
          Stabilization Window Seconds:  60
          Tolerance:                     100m
    Scaling Modifiers:
  Max Replica Count:  10
  Min Replica Count:  1
  Scale Target Ref:
    API Version:  kaito.sh/v1alpha1
    Kind:         InferenceSet
    Name:         phi-2
  Triggers:
    Authentication Ref:
      Kind:  ClusterTriggerAuthentication
      Name:  keda-kaito-scaler-creds
    Metadata:
      Inference Set Name:       phi-2
      Inference Set Namespace:  default
      Metric Name:              vllm:num_requests_waiting
      Metric Path:              /metrics
      Metric Port:              5000
      Metric Protocol:          https
      Scaler Address:           keda-kaito-scaler-svc.kaito-workspace.svc.cluster.local:10450
      Scaler Name:              keda-kaito-scaler
      Scrape Timeout:           5s
      Threshold:                10
    Metric Type:                AverageValue
    Name:                       keda-kaito-scaler
    Type:                       external
Status:
  Authentications Types:  keda-kaito-scaler-creds
  Conditions:
    Message:  ScaledObject is defined correctly and is ready for scaling
    Reason:   ScaledObjectReady
    Status:   True
    Type:     Ready
    Message:  Scaling is performed because triggers are active
    Reason:   ScalerActive
    Status:   True
    Type:     Active
    Message:  No fallbacks are active on this scaled object
    Reason:   NoFallbackFound
    Status:   False
    Type:     Fallback
    Status:   False
    Type:     Paused
  External Metric Names:
    s0-vllm:num_requests_waiting
  Hpa Name:                keda-hpa-phi-2
  Last Active Time:        2025-11-14T03:14:29Z
  Original Replica Count:  1
  Scale Target GVKR:
    Group:            kaito.sh
    Kind:             InferenceSet
    Resource:         inferencesets
    Version:          v1alpha1
  Scale Target Kind:  kaito.sh/v1alpha1.InferenceSet
  Triggers Types:     external
Events:
  Type     Reason              Age                   From           Message
  ----     ------              ----                  ----           -------
  Normal   KEDAScalersStarted  50m (x1471 over 13h)  keda-operator  Scaler external is built
  Warning  KEDAScalerFailed    50m (x1439 over 12h)  keda-operator  rpc error: code = Internal desc = failed to get pod metrics: rpc error: code = Internal desc = failed to resolve metric(vllm:num_requests_waiting) from pod: default/phi-2-kmst5-84558bb4cc-d8rkv
```

</details>

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: