### PR TITLE
chore: bump chart and image versions from 0.3.0 to 0.3.3

### DIFF
--- a/charts/keda-kaito-scaler/Chart.yaml
+++ b/charts/keda-kaito-scaler/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.3.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.3.0"
+appVersion: "v0.3.3"

--- a/charts/keda-kaito-scaler/values.yaml
+++ b/charts/keda-kaito-scaler/values.yaml
@@ -8,7 +8,7 @@ nameOverrider: ""
 image:
     registry: ghcr.io
     repository: kaito-project/keda-kaito-scaler
-    tag: 0.3.0
+    tag: 0.3.3
     pullSecrets: []
 
 ports:


### PR DESCRIPTION
Bump all version references to 0.3.3:
- `Chart.yaml`: version 0.3.0 → 0.3.3, appVersion v0.3.0 → v0.3.3
- `values.yaml`: default image tag 0.3.0 → 0.3.3