### PR TITLE
feat: support configure min-replicas from inferenceset annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ helm upgrade --install keda-kaito-scaler -n kaito-workspace keda-kaito-scaler/ke
      - optional, specifies the minimum number of replicas for the ScaledObject. If not set or less than 1, it will be set to 1.
    - `scaledobject.kaito.sh/max-replicas`
      - optional, specifies the maximum number of replicas for the ScaledObject. When this annotation is not set, the value is computed from `spec.nodeCountLimit` when available.
-     - auto-provisioning requires either `spec.nodeCountLimit` to be set or this annotation to be present with a value greater than `1`; if neither is true, the controller will not auto-provision a ScaledObject.
+     - this annotation takes precedence when present: if set, it must have a value greater than `1`, otherwise the controller will not auto-provision a ScaledObject even when `spec.nodeCountLimit` is set. If the annotation is absent, auto-provisioning requires `spec.nodeCountLimit` to be set.
      - when set, `max-replicas` must be greater than or equal to `min-replicas`; otherwise the controller will skip reconciling the InferenceSet and emit an `InvalidReplicaRange` warning event.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ helm upgrade --install keda-kaito-scaler -n kaito-workspace keda-kaito-scaler/ke
    - `scaledobject.kaito.sh/min-replicas`
      - optional, specifies the minimum number of replicas for the ScaledObject. If not set or less than 1, it will be set to 1.
    - `scaledobject.kaito.sh/max-replicas`
-     - optional, specifies the maximum number of replicas for the ScaledObject. If not set, it will be computed from `spec.nodeCountLimit` when available, otherwise defaults to 1.
+     - optional, specifies the maximum number of replicas for the ScaledObject. When this annotation is not set, the value is computed from `spec.nodeCountLimit` when available.
+     - auto-provisioning requires either `spec.nodeCountLimit` to be set or this annotation to be present with a value greater than `1`; if neither is true, the controller will not auto-provision a ScaledObject.
+     - when set, `max-replicas` must be greater than or equal to `min-replicas`; otherwise the controller will skip reconciling the InferenceSet and emit an `InvalidReplicaRange` warning event.
 
 ```bash
 cat <<EOF | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ helm upgrade --install keda-kaito-scaler -n kaito-workspace keda-kaito-scaler/ke
      - optional, specifies the metric name collected from the vLLM pod, which is used for monitoring and triggering the scaling operation, default is `vllm:num_requests_waiting`
    - `scaledobject.kaito.sh/threshold`
      - required, specifies the threshold for the monitored metric that triggers the scaling operation
+   - `scaledobject.kaito.sh/min-replicas`
+     - optional, specifies the minimum number of replicas for the ScaledObject. If not set or less than 1, it will be set to 1.
+   - `scaledobject.kaito.sh/max-replicas`
+     - optional, specifies the maximum number of replicas for the ScaledObject. If not set, it will be computed from `spec.nodeCountLimit` when available, otherwise defaults to 1.
 
 ```bash
 cat <<EOF | kubectl apply -f -

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -157,6 +157,8 @@ func (c *Controller) resolveMaxReplicas(ctx context.Context, is *kaitov1alpha1.I
 	maxReplicas := is.Spec.NodeCountLimit / int(targetNodeCount)
 	if maxReplicas < 1 {
 		maxReplicas = 1
+	} else if maxReplicas > math.MaxInt32 {
+		maxReplicas = math.MaxInt32
 	}
 	return maxReplicas, false, nil
 }
@@ -187,7 +189,7 @@ func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.In
 	case 0:
 		return c.Create(ctx, c.buildScaledObject(is, minReplicas, maxReplicas, threshold))
 	case 1:
-		return c.updateScaledObject(ctx, &existing[0], minReplicas, maxReplicas, threshold)
+		return c.updateScaledObject(ctx, is, &existing[0], minReplicas, maxReplicas, threshold)
 	default:
 		// Keep the oldest one, delete the rest, then reconcile the kept one to
 		// the desired spec so it does not go stale after annotation changes.
@@ -199,7 +201,7 @@ func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.In
 				return err
 			}
 		}
-		return c.updateScaledObject(ctx, &existing[0], minReplicas, maxReplicas, threshold)
+		return c.updateScaledObject(ctx, is, &existing[0], minReplicas, maxReplicas, threshold)
 	}
 }
 
@@ -238,7 +240,7 @@ func (c *Controller) buildScaledObject(is *kaitov1alpha1.InferenceSet, minReplic
 	}
 }
 
-func (c *Controller) updateScaledObject(ctx context.Context, so *v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold string) error {
+func (c *Controller) updateScaledObject(ctx context.Context, is *kaitov1alpha1.InferenceSet, so *v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold string) error {
 	updated := false
 
 	if so.Spec.MinReplicaCount == nil || *so.Spec.MinReplicaCount != int32(minReplicas) {
@@ -249,7 +251,11 @@ func (c *Controller) updateScaledObject(ctx context.Context, so *v1alpha1.Scaled
 		so.Spec.MaxReplicaCount = ptr.To(int32(maxReplicas))
 		updated = true
 	}
-	if len(so.Spec.Triggers) > 0 {
+	if len(so.Spec.Triggers) == 0 {
+		// Restore triggers if they were removed (e.g., manual edit drift).
+		so.Spec.Triggers = getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold)
+		updated = true
+	} else {
 		if so.Spec.Triggers[0].Metadata == nil {
 			so.Spec.Triggers[0].Metadata = make(map[string]string)
 		}

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -46,12 +46,25 @@ import (
 
 const (
 	AnnotationKeyAutoProvision = "scaledobject.kaito.sh/auto-provision"
+	AnnotationKeyMinReplicas   = "scaledobject.kaito.sh/min-replicas"
 	AnnotationKeyMaxReplicas   = "scaledobject.kaito.sh/max-replicas"
 	AnnotationKeyThreshold     = "scaledobject.kaito.sh/threshold"
 
 	AnnotationKeyManagedBy = "scaledobject.kaito.sh/managed-by"
 	InferenceSet           = "InferenceSet"
+
+	inferenceSetAPIVersion = "kaito.sh/v1alpha1"
+	requeueInterval        = 5 * time.Second
 )
+
+// watchedAnnotations are the annotations whose changes should trigger a
+// reconcile of the owning InferenceSet.
+var watchedAnnotations = []string{
+	AnnotationKeyAutoProvision,
+	AnnotationKeyMinReplicas,
+	AnnotationKeyMaxReplicas,
+	AnnotationKeyThreshold,
+}
 
 type Controller struct {
 	client.Client
@@ -71,125 +84,158 @@ func (c *Controller) Reconcile(ctx context.Context, is *kaitov1alpha1.InferenceS
 		return reconcile.Result{}, nil
 	}
 
-	var maxReplicas int
-	if is.Spec.NodeCountLimit != 0 {
-		workspaceList, err := inferenceset.ListWorkspaces(ctx, is, c.Client)
-		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to list workspaces for inference set %s/%s: %v", is.Namespace, is.Name, err)
-		}
-
-		var targetNodeCount int32
-		for i := range workspaceList.Items {
-			if workspaceList.Items[i].Status.TargetNodeCount != 0 {
-				targetNodeCount = workspaceList.Items[i].Status.TargetNodeCount
-				break
-			}
-		}
-
-		if targetNodeCount == 0 {
-			logger.Info("target node count from workspaces for inference set is zero, and requeue after 5 seconds", "namespace", is.Namespace, "name", is.Name)
-			return reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-
-		maxReplicas = is.Spec.NodeCountLimit / int(targetNodeCount)
-		if maxReplicas < 1 {
-			maxReplicas = 1
-		}
-	} else if maxReplicasStr, ok := is.Annotations[AnnotationKeyMaxReplicas]; ok {
-		maxReplicas, _ = strconv.Atoi(maxReplicasStr)
-	} else {
-		maxReplicas = 1
+	maxReplicas, requeue, err := c.resolveMaxReplicas(ctx, is)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if requeue {
+		logger.Info("target node count from workspaces for inference set is zero, and requeue after 5 seconds", "namespace", is.Namespace, "name", is.Name)
+		return reconcile.Result{RequeueAfter: requeueInterval}, nil
 	}
 
+	minReplicas := resolveMinReplicas(is.Annotations)
 	threshold := is.Annotations[AnnotationKeyThreshold]
 
-	// list all scaled objects in the same namespace
-	var scaledObjectList v1alpha1.ScaledObjectList
-	if err := c.List(ctx, &scaledObjectList, client.InNamespace(is.Namespace)); err != nil {
+	managedScaledObjects, err := c.listManagedScaledObjects(ctx, is)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	// filter the scaled objects related to the workspace and auto provisioning
-	var filteredScaledObjects []v1alpha1.ScaledObject
-	for _, scaledObject := range scaledObjectList.Items {
-		if scaledObject.Spec.ScaleTargetRef.Name == is.Name && scaledObject.Spec.ScaleTargetRef.Kind == InferenceSet {
-			if scaledObject.Annotations[AnnotationKeyManagedBy] == scaler.ScalerName {
-				filteredScaledObjects = append(filteredScaledObjects, scaledObject)
-			}
+	return reconcile.Result{}, c.syncScaledObjects(ctx, is, managedScaledObjects, minReplicas, maxReplicas, threshold)
+}
+
+// resolveMaxReplicas computes the max replicas for the ScaledObject. When
+// NodeCountLimit is set, it derives the value from workspaces and may signal a
+// requeue if information is not yet available. Otherwise it falls back to the
+// max-replicas annotation or a default of 1.
+func (c *Controller) resolveMaxReplicas(ctx context.Context, is *kaitov1alpha1.InferenceSet) (int, bool, error) {
+	if is.Spec.NodeCountLimit == 0 {
+		if maxReplicasStr, ok := is.Annotations[AnnotationKeyMaxReplicas]; ok {
+			v, _ := strconv.Atoi(maxReplicasStr)
+			return v, false, nil
 		}
+		return 1, false, nil
 	}
 
-	// if no scaled object found, create one
-	if len(filteredScaledObjects) == 0 {
-		newScaledObject := &v1alpha1.ScaledObject{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      is.Name,
-				Namespace: is.Namespace,
-				Annotations: map[string]string{
-					AnnotationKeyManagedBy: scaler.ScalerName,
-				},
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion:         "kaito.sh/v1alpha1",
-						Kind:               InferenceSet,
-						Name:               is.Name,
-						UID:                is.UID,
-						Controller:         ptr.To(true),
-						BlockOwnerDeletion: ptr.To(true),
-					},
-				},
-			},
-			Spec: v1alpha1.ScaledObjectSpec{
-				Advanced: &v1alpha1.AdvancedConfig{
-					HorizontalPodAutoscalerConfig: getDefaultHorizontalPodAutoscalerConfig(),
-				},
-				ScaleTargetRef: &v1alpha1.ScaleTarget{
-					Name:       is.Name,
-					APIVersion: "kaito.sh/v1alpha1",
-					Kind:       InferenceSet,
-				},
-				MinReplicaCount: ptr.To(int32(1)),
-				MaxReplicaCount: ptr.To(int32(maxReplicas)),
-				Triggers:        getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold),
-			},
-		}
+	workspaceList, err := inferenceset.ListWorkspaces(ctx, is, c.Client)
+	if err != nil {
+		return 0, false, fmt.Errorf("failed to list workspaces for inference set %s/%s: %v", is.Namespace, is.Name, err)
+	}
 
-		if err := c.Create(ctx, newScaledObject); err != nil {
-			return reconcile.Result{}, err
+	var targetNodeCount int32
+	for i := range workspaceList.Items {
+		if workspaceList.Items[i].Status.TargetNodeCount != 0 {
+			targetNodeCount = workspaceList.Items[i].Status.TargetNodeCount
+			break
 		}
-	} else if len(filteredScaledObjects) == 1 {
-		// update the existing scaled object if annotation values changed
-		existingScaledObject := filteredScaledObjects[0]
-		updated := false
+	}
+	if targetNodeCount == 0 {
+		return 0, true, nil
+	}
 
-		if *existingScaledObject.Spec.MaxReplicaCount != int32(maxReplicas) {
-			existingScaledObject.Spec.MaxReplicaCount = ptr.To(int32(maxReplicas))
-			updated = true
-		}
-		if existingScaledObject.Spec.Triggers[0].Metadata["threshold"] != threshold {
-			existingScaledObject.Spec.Triggers[0].Metadata["threshold"] = threshold
-			updated = true
-		}
+	maxReplicas := is.Spec.NodeCountLimit / int(targetNodeCount)
+	if maxReplicas < 1 {
+		maxReplicas = 1
+	}
+	return maxReplicas, false, nil
+}
 
-		if updated {
-			if err := c.Update(ctx, &existingScaledObject); err != nil {
-				return reconcile.Result{}, err
-			}
+// listManagedScaledObjects returns ScaledObjects that target the given
+// InferenceSet and are managed by this scaler.
+func (c *Controller) listManagedScaledObjects(ctx context.Context, is *kaitov1alpha1.InferenceSet) ([]v1alpha1.ScaledObject, error) {
+	var scaledObjectList v1alpha1.ScaledObjectList
+	if err := c.List(ctx, &scaledObjectList, client.InNamespace(is.Namespace)); err != nil {
+		return nil, err
+	}
+
+	var managed []v1alpha1.ScaledObject
+	for _, so := range scaledObjectList.Items {
+		if so.Spec.ScaleTargetRef.Name == is.Name &&
+			so.Spec.ScaleTargetRef.Kind == InferenceSet &&
+			so.Annotations[AnnotationKeyManagedBy] == scaler.ScalerName {
+			managed = append(managed, so)
 		}
-	} else {
-		// sort by creation timestamp, and delete new ones.
-		sort.SliceStable(filteredScaledObjects, func(i, j int) bool {
-			return filteredScaledObjects[i].CreationTimestamp.Before(&filteredScaledObjects[j].CreationTimestamp)
+	}
+	return managed, nil
+}
+
+// syncScaledObjects creates, updates, or deduplicates managed ScaledObjects so
+// that exactly one matches the desired spec.
+func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.InferenceSet, existing []v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold string) error {
+	switch len(existing) {
+	case 0:
+		return c.Create(ctx, c.buildScaledObject(is, minReplicas, maxReplicas, threshold))
+	case 1:
+		return c.updateScaledObject(ctx, &existing[0], minReplicas, maxReplicas, threshold)
+	default:
+		// Keep the oldest one, delete the rest.
+		sort.SliceStable(existing, func(i, j int) bool {
+			return existing[i].CreationTimestamp.Before(&existing[j].CreationTimestamp)
 		})
-
-		for i := 1; i < len(filteredScaledObjects); i++ {
-			if err := c.Delete(ctx, &filteredScaledObjects[i]); err != nil {
-				return reconcile.Result{}, err
+		for i := 1; i < len(existing); i++ {
+			if err := c.Delete(ctx, &existing[i]); err != nil {
+				return err
 			}
 		}
+		return nil
+	}
+}
+
+func (c *Controller) buildScaledObject(is *kaitov1alpha1.InferenceSet, minReplicas, maxReplicas int, threshold string) *v1alpha1.ScaledObject {
+	return &v1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      is.Name,
+			Namespace: is.Namespace,
+			Annotations: map[string]string{
+				AnnotationKeyManagedBy: scaler.ScalerName,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         inferenceSetAPIVersion,
+					Kind:               InferenceSet,
+					Name:               is.Name,
+					UID:                is.UID,
+					Controller:         ptr.To(true),
+					BlockOwnerDeletion: ptr.To(true),
+				},
+			},
+		},
+		Spec: v1alpha1.ScaledObjectSpec{
+			Advanced: &v1alpha1.AdvancedConfig{
+				HorizontalPodAutoscalerConfig: getDefaultHorizontalPodAutoscalerConfig(),
+			},
+			ScaleTargetRef: &v1alpha1.ScaleTarget{
+				Name:       is.Name,
+				APIVersion: inferenceSetAPIVersion,
+				Kind:       InferenceSet,
+			},
+			MinReplicaCount: ptr.To(int32(minReplicas)),
+			MaxReplicaCount: ptr.To(int32(maxReplicas)),
+			Triggers:        getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold),
+		},
+	}
+}
+
+func (c *Controller) updateScaledObject(ctx context.Context, so *v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold string) error {
+	updated := false
+
+	if so.Spec.MinReplicaCount == nil || *so.Spec.MinReplicaCount != int32(minReplicas) {
+		so.Spec.MinReplicaCount = ptr.To(int32(minReplicas))
+		updated = true
+	}
+	if so.Spec.MaxReplicaCount == nil || *so.Spec.MaxReplicaCount != int32(maxReplicas) {
+		so.Spec.MaxReplicaCount = ptr.To(int32(maxReplicas))
+		updated = true
+	}
+	if len(so.Spec.Triggers) > 0 && so.Spec.Triggers[0].Metadata["threshold"] != threshold {
+		so.Spec.Triggers[0].Metadata["threshold"] = threshold
+		updated = true
 	}
 
-	return reconcile.Result{}, nil
+	if !updated {
+		return nil
+	}
+	return c.Update(ctx, so)
 }
 
 func generateInferenceSetPredicateFunc() predicate.Predicate {
@@ -212,11 +258,11 @@ func generateInferenceSetPredicateFunc() predicate.Predicate {
 				return false
 			}
 
-			// check auto-provision, max-replicas, threshold annotation changes
-			if oldInferenceSet.Annotations[AnnotationKeyAutoProvision] != newInferenceSet.Annotations[AnnotationKeyAutoProvision] ||
-				oldInferenceSet.Annotations[AnnotationKeyMaxReplicas] != newInferenceSet.Annotations[AnnotationKeyMaxReplicas] ||
-				oldInferenceSet.Annotations[AnnotationKeyThreshold] != newInferenceSet.Annotations[AnnotationKeyThreshold] {
-				return enableAutoProvisioning(newInferenceSet)
+			// Reconcile when any watched annotation changes.
+			for _, key := range watchedAnnotations {
+				if oldInferenceSet.Annotations[key] != newInferenceSet.Annotations[key] {
+					return enableAutoProvisioning(newInferenceSet)
+				}
 			}
 			return false
 		},
@@ -224,6 +270,15 @@ func generateInferenceSetPredicateFunc() predicate.Predicate {
 			return false
 		},
 	}
+}
+
+func resolveMinReplicas(annotations map[string]string) int {
+	if minReplicasStr, ok := annotations[AnnotationKeyMinReplicas]; ok {
+		if v, err := strconv.Atoi(minReplicasStr); err == nil && v > 1 {
+			return v
+		}
+	}
+	return 1
 }
 
 func enableAutoProvisioning(inferenceSet *kaitov1alpha1.InferenceSet) bool {
@@ -328,10 +383,16 @@ func getDefaultKedaKaitoScalerTriggers(inferenceSetName, inferenceSetNamespace, 
 				scaler.InferenceSetNamespaceInMetadata: inferenceSetNamespace,
 				scaler.ScalerAddressInMetadata:         fmt.Sprintf("keda-kaito-scaler-svc.%s.svc.cluster.local:%d", scalerNamespace, 10450),
 				scaler.MetricNameInMetadata:            "vllm:num_requests_waiting",
-				scaler.MetricProtocolInMetadata:        "http",
-				scaler.MetricPortInMetadata:            "80",
-				scaler.MetricPathInMetadata:            "/metrics",
-				scaler.ScrapeTimeoutInMetadata:         "5s",
+				// Kaito creates a ClusterIP Service per workspace that exposes the
+				// vLLM inference server on spec.ports[name="http"] with Port=80 and
+				// TargetPort=consts.PortInferenceServer (5000). The server currently
+				// speaks plain HTTP (no TLS), so the scaler scrapes /metrics over
+				// http://<svc>:80. The protocol is kept configurable here so that
+				// https can be used in the future if Kaito enables TLS.
+				scaler.MetricProtocolInMetadata: "http",
+				scaler.MetricPortInMetadata:     "80",
+				scaler.MetricPathInMetadata:     "/metrics",
+				scaler.ScrapeTimeoutInMetadata:  "5s",
 			},
 			AuthenticationRef: &v1alpha1.AuthenticationRef{
 				Name: "keda-kaito-scaler-creds",

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -25,9 +25,11 @@ import (
 	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"golang.org/x/time/rate"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	controllerruntime "sigs.k8s.io/controller-runtime"
@@ -69,12 +71,14 @@ var watchedAnnotations = []string{
 type Controller struct {
 	client.Client
 	ScalerNamespace string
+	Recorder        record.EventRecorder
 }
 
-func NewAutoProvisionController(c client.Client, scalerNamespace string) *Controller {
+func NewAutoProvisionController(c client.Client, scalerNamespace string, recorder record.EventRecorder) *Controller {
 	return &Controller{
 		Client:          c,
 		ScalerNamespace: scalerNamespace,
+		Recorder:        recorder,
 	}
 }
 
@@ -94,6 +98,17 @@ func (c *Controller) Reconcile(ctx context.Context, is *kaitov1alpha1.InferenceS
 	}
 
 	minReplicas := resolveMinReplicas(is.Annotations)
+	if maxReplicas < minReplicas {
+		logger.Info("skip reconciling inference set because max-replicas is less than min-replicas",
+			"namespace", is.Namespace, "name", is.Name,
+			"minReplicas", minReplicas, "maxReplicas", maxReplicas)
+		if c.Recorder != nil {
+			c.Recorder.Eventf(is, corev1.EventTypeWarning, "InvalidReplicaRange",
+				"Skip auto-provisioning ScaledObject: max-replicas (%d) is less than min-replicas (%d)",
+				maxReplicas, minReplicas)
+		}
+		return reconcile.Result{}, nil
+	}
 	threshold := is.Annotations[AnnotationKeyThreshold]
 
 	managedScaledObjects, err := c.listManagedScaledObjects(ctx, is)
@@ -168,7 +183,8 @@ func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.In
 	case 1:
 		return c.updateScaledObject(ctx, &existing[0], minReplicas, maxReplicas, threshold)
 	default:
-		// Keep the oldest one, delete the rest.
+		// Keep the oldest one, delete the rest, then reconcile the kept one to
+		// the desired spec so it does not go stale after annotation changes.
 		sort.SliceStable(existing, func(i, j int) bool {
 			return existing[i].CreationTimestamp.Before(&existing[j].CreationTimestamp)
 		})
@@ -177,7 +193,7 @@ func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.In
 				return err
 			}
 		}
-		return nil
+		return c.updateScaledObject(ctx, &existing[0], minReplicas, maxReplicas, threshold)
 	}
 }
 

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -16,6 +16,7 @@ package autoprovision
 import (
 	"context"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"time"
@@ -126,7 +127,12 @@ func (c *Controller) Reconcile(ctx context.Context, is *kaitov1alpha1.InferenceS
 func (c *Controller) resolveMaxReplicas(ctx context.Context, is *kaitov1alpha1.InferenceSet) (int, bool, error) {
 	if is.Spec.NodeCountLimit == 0 {
 		if maxReplicasStr, ok := is.Annotations[AnnotationKeyMaxReplicas]; ok {
-			v, _ := strconv.Atoi(maxReplicasStr)
+			v, err := strconv.Atoi(maxReplicasStr)
+			if err != nil || v < 1 {
+				v = 1
+			} else if v > math.MaxInt32 {
+				v = math.MaxInt32
+			}
 			return v, false, nil
 		}
 		return 1, false, nil
@@ -243,9 +249,14 @@ func (c *Controller) updateScaledObject(ctx context.Context, so *v1alpha1.Scaled
 		so.Spec.MaxReplicaCount = ptr.To(int32(maxReplicas))
 		updated = true
 	}
-	if len(so.Spec.Triggers) > 0 && so.Spec.Triggers[0].Metadata["threshold"] != threshold {
-		so.Spec.Triggers[0].Metadata["threshold"] = threshold
-		updated = true
+	if len(so.Spec.Triggers) > 0 {
+		if so.Spec.Triggers[0].Metadata == nil {
+			so.Spec.Triggers[0].Metadata = make(map[string]string)
+		}
+		if so.Spec.Triggers[0].Metadata["threshold"] != threshold {
+			so.Spec.Triggers[0].Metadata["threshold"] = threshold
+			updated = true
+		}
 	}
 
 	if !updated {
@@ -291,6 +302,9 @@ func generateInferenceSetPredicateFunc() predicate.Predicate {
 func resolveMinReplicas(annotations map[string]string) int {
 	if minReplicasStr, ok := annotations[AnnotationKeyMinReplicas]; ok {
 		if v, err := strconv.Atoi(minReplicasStr); err == nil && v > 1 {
+			if v > math.MaxInt32 {
+				return math.MaxInt32
+			}
 			return v
 		}
 	}

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -94,7 +94,8 @@ func (c *Controller) Reconcile(ctx context.Context, is *kaitov1alpha1.InferenceS
 		return reconcile.Result{}, err
 	}
 	if requeue {
-		logger.Info("target node count from workspaces for inference set is zero, and requeue after 5 seconds", "namespace", is.Namespace, "name", is.Name)
+		logger.Info("target node count from workspaces for inference set is zero, requeueing",
+			"namespace", is.Namespace, "name", is.Name, "requeueAfter", requeueInterval.String())
 		return reconcile.Result{RequeueAfter: requeueInterval}, nil
 	}
 

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -94,7 +94,7 @@ func (c *Controller) Reconcile(ctx context.Context, is *kaitov1alpha1.InferenceS
 		return reconcile.Result{}, err
 	}
 	if requeue {
-		logger.Info("target node count from workspaces for inference set is zero, requeueing",
+		logger.Info("target node count from workspaces for inference set is zero, requeuing",
 			"namespace", is.Namespace, "name", is.Name, "requeueAfter", requeueInterval.String())
 		return reconcile.Result{RequeueAfter: requeueInterval}, nil
 	}

--- a/pkg/controllers/autoprovision/auto_provision_controller_test.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller_test.go
@@ -224,3 +224,53 @@ func TestGetDefaultHorizontalPodAutoscalerConfig_Consistency(t *testing.T) {
 	assert.Equal(t, *config1.Behavior.ScaleDown.SelectPolicy, *config2.Behavior.ScaleDown.SelectPolicy)
 	assert.True(t, config1.Behavior.ScaleDown.Tolerance.Equal(*config2.Behavior.ScaleDown.Tolerance))
 }
+
+func TestResolveMinReplicas(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    int
+	}{
+		{
+			name:        "annotation not set returns 1",
+			annotations: nil,
+			expected:    1,
+		},
+		{
+			name:        "empty annotations returns 1",
+			annotations: map[string]string{},
+			expected:    1,
+		},
+		{
+			name:        "annotation value less than 1 is clamped to 1",
+			annotations: map[string]string{AnnotationKeyMinReplicas: "0"},
+			expected:    1,
+		},
+		{
+			name:        "annotation value equal to 1 returns 1",
+			annotations: map[string]string{AnnotationKeyMinReplicas: "1"},
+			expected:    1,
+		},
+		{
+			name:        "negative annotation value is clamped to 1",
+			annotations: map[string]string{AnnotationKeyMinReplicas: "-5"},
+			expected:    1,
+		},
+		{
+			name:        "invalid annotation value falls back to 1",
+			annotations: map[string]string{AnnotationKeyMinReplicas: "abc"},
+			expected:    1,
+		},
+		{
+			name:        "valid value greater than 1 is returned",
+			annotations: map[string]string{AnnotationKeyMinReplicas: "3"},
+			expected:    3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, resolveMinReplicas(tt.annotations))
+		})
+	}
+}

--- a/pkg/controllers/autoprovision/auto_provision_controller_test.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller_test.go
@@ -14,12 +14,20 @@
 package autoprovision
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"testing"
 
+	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/stretchr/testify/assert"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kaito-project/keda-kaito-scaler/pkg/scaler"
 )
@@ -271,6 +279,124 @@ func TestResolveMinReplicas(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, resolveMinReplicas(tt.annotations))
+		})
+	}
+}
+
+func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	assert.NoError(t, kaitov1alpha1.AddToScheme(scheme))
+	assert.NoError(t, kaitov1beta1.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func TestResolveMaxReplicas(t *testing.T) {
+	ctx := context.Background()
+	const inferenceSetName = "test-is"
+	const inferenceSetNamespace = "default"
+
+	newInferenceSet := func(nodeCountLimit int, annotations map[string]string) *kaitov1alpha1.InferenceSet {
+		return &kaitov1alpha1.InferenceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        inferenceSetName,
+				Namespace:   inferenceSetNamespace,
+				Annotations: annotations,
+			},
+			Spec: kaitov1alpha1.InferenceSetSpec{
+				NodeCountLimit: nodeCountLimit,
+			},
+		}
+	}
+
+	newWorkspace := func(targetNodeCount int32) *kaitov1beta1.Workspace {
+		return &kaitov1beta1.Workspace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      inferenceSetName + "-0",
+				Namespace: inferenceSetNamespace,
+				Labels: map[string]string{
+					"inferenceset.kaito.sh/created-by": inferenceSetName,
+				},
+			},
+			Status: kaitov1beta1.WorkspaceStatus{
+				TargetNodeCount: targetNodeCount,
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		is              *kaitov1alpha1.InferenceSet
+		workspaces      []client.Object
+		expectedValue   int
+		expectedRequeue bool
+		expectError     bool
+	}{
+		{
+			name:          "NodeCountLimit=0 without annotation returns default 1",
+			is:            newInferenceSet(0, nil),
+			expectedValue: 1,
+		},
+		{
+			name:          "NodeCountLimit=0 with valid annotation returns annotation value",
+			is:            newInferenceSet(0, map[string]string{AnnotationKeyMaxReplicas: "5"}),
+			expectedValue: 5,
+		},
+		{
+			name:          "NodeCountLimit=0 with annotation <1 is clamped to 1",
+			is:            newInferenceSet(0, map[string]string{AnnotationKeyMaxReplicas: "0"}),
+			expectedValue: 1,
+		},
+		{
+			name:          "NodeCountLimit=0 with invalid annotation is clamped to 1",
+			is:            newInferenceSet(0, map[string]string{AnnotationKeyMaxReplicas: "abc"}),
+			expectedValue: 1,
+		},
+		{
+			name:          "NodeCountLimit=0 with annotation exceeding MaxInt32 is clamped to MaxInt32",
+			is:            newInferenceSet(0, map[string]string{AnnotationKeyMaxReplicas: fmt.Sprintf("%d", int64(math.MaxInt32)+1)}),
+			expectedValue: math.MaxInt32,
+		},
+		{
+			name:            "NodeCountLimit>0 with no workspaces requests requeue",
+			is:              newInferenceSet(10, nil),
+			workspaces:      nil,
+			expectedRequeue: true,
+		},
+		{
+			name:            "NodeCountLimit>0 with workspace targetNodeCount=0 requests requeue",
+			is:              newInferenceSet(10, nil),
+			workspaces:      []client.Object{newWorkspace(0)},
+			expectedRequeue: true,
+		},
+		{
+			name:          "NodeCountLimit>0 with workspace targetNodeCount=2 returns 5",
+			is:            newInferenceSet(10, nil),
+			workspaces:    []client.Object{newWorkspace(2)},
+			expectedValue: 5,
+		},
+		{
+			name:          "NodeCountLimit>0 with division result <1 is clamped to 1",
+			is:            newInferenceSet(1, nil),
+			workspaces:    []client.Object{newWorkspace(4)},
+			expectedValue: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newFakeClient(t, tt.workspaces...)
+			ctrl := &Controller{Client: c}
+			value, requeue, err := ctrl.resolveMaxReplicas(ctx, tt.is)
+			if tt.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedRequeue, requeue)
+			if !tt.expectedRequeue {
+				assert.Equal(t, tt.expectedValue, value)
+			}
 		})
 	}
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -26,7 +26,7 @@ import (
 
 func NewControllers(mgr manager.Manager, scalerNamespace string) []controller.Controller {
 	return []controller.Controller{
-		autoprovision.NewAutoProvisionController(mgr.GetClient(), scalerNamespace),
+		autoprovision.NewAutoProvisionController(mgr.GetClient(), scalerNamespace, mgr.GetEventRecorderFor("keda-kaito-scaler")),
 		// add controllers here
 	}
 }

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -280,11 +280,9 @@ func parseScalerMetadata(sor *externalscaler.ScaledObjectRef, metricName string)
 }
 
 func (e *KaitoScaler) getServiceMetric(serviceName, serviceNamespace string, scalerConfig *Config) (float64, error) {
-	var transport *http.Transport
+	transport := e.httpTransport
 	if scalerConfig.MetricProtocol == "https" {
 		transport = e.tlsTransport
-	} else {
-		transport = e.httpTransport
 	}
 
 	httpClient := &http.Client{
@@ -292,6 +290,11 @@ func (e *KaitoScaler) getServiceMetric(serviceName, serviceNamespace string, sca
 		Timeout:   scalerConfig.ScrapeTimeout,
 	}
 
+	// NOTE: Kaito currently exposes the vLLM inference server (and its Prometheus
+	// /metrics endpoint) as plain HTTP on the workspace Service
+	// (spec.ports[name="http"], Port=80 -> TargetPort=PortInferenceServer=5000).
+	// The protocol is kept configurable via the ScaledObject metadata so that
+	// https can be used in the future if Kaito enables TLS on the inference server.
 	metricURL := fmt.Sprintf("%s://%s.%s.svc.cluster.local:%s%s", scalerConfig.MetricProtocol, serviceName, serviceNamespace, scalerConfig.MetricPort, scalerConfig.MetricPath)
 	klog.V(6).Infof("scraping metrics from service %s/%s: %s", serviceNamespace, serviceName, metricURL)
 	resp, err := httpClient.Get(metricURL)


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
1. support min-replicas configuraiton
2. fix http protocol for vllm pod metrics

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: