### PR TITLE
feat: improve keda kaito scaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,23 +66,50 @@ keda-kaito-scaler/keda-kaito-scaler     0.0.1           v0.0.1        A Helm cha
 ```
 
 ```bash
-helm upgrade --install keda-kaito-scaler -n kaito-workspace keda-kaito-scaler/keda-kaito-scaler --create-namespace
+helm upgrade --install keda-kaito-scaler -n keda keda-kaito-scaler/keda-kaito-scaler
 ```
 
+> **keda-kaito-scaler must be installed in the same namespace as KEDA**
+> (`keda` in the command above). The chart's `ClusterTriggerAuthentication`
+> references TLS secrets created in the scaler's namespace, and KEDA only
+> resolves those secrets when it can read them from its own namespace.
+
 ### Create a Kaito InferenceSet for running inference workloads
- - The following example creates an InferenceSet for the phi-4-mini model, using annotations with the prefix `scaledobject.kaito.sh/` to supply parameter inputs for the KEDA Kaito Scaler:
-   - `scaledobject.kaito.sh/auto-provision`
-     - required, specifies whether KEDA Kaito Scaler will automatically provision a ScaledObject based on the `InferenceSet` object
-   - `scaledobject.kaito.sh/metricName`
-     - optional, specifies the metric name collected from the vLLM pod, which is used for monitoring and triggering the scaling operation, default is `vllm:num_requests_waiting`
-   - `scaledobject.kaito.sh/threshold`
-     - required, specifies the threshold for the monitored metric that triggers the scaling operation
-   - `scaledobject.kaito.sh/min-replicas`
-     - optional, specifies the minimum number of replicas for the ScaledObject. If not set or less than 1, it will be set to 1.
-   - `scaledobject.kaito.sh/max-replicas`
-     - optional, specifies the maximum number of replicas for the ScaledObject. When this annotation is not set, the value is computed from `spec.nodeCountLimit` when available.
-     - this annotation takes precedence when present: if set, it must have a value greater than `1`, otherwise the controller will not auto-provision a ScaledObject even when `spec.nodeCountLimit` is set. If the annotation is absent, auto-provisioning requires `spec.nodeCountLimit` to be set.
-     - when set, `max-replicas` must be greater than or equal to `min-replicas`; otherwise the controller will skip reconciling the InferenceSet and emit an `InvalidReplicaRange` warning event.
+
+You can drive autoscaling in two ways:
+
+1. **Auto-provision mode (recommended)** — annotate the `InferenceSet` and let
+   keda-kaito-scaler create and reconcile the `ScaledObject` for you.
+2. **Manual mode** — author the `ScaledObject` yourself and point its `external`
+   trigger at the keda-kaito-scaler service.
+
+Both modes share the same scaling semantics:
+
+- The trigger uses HPA `metricType: AverageValue`. The scaler returns the
+  **sum** of the metric across all `Workspace` services owned by the
+  `InferenceSet`, and `threshold` is the **per-replica** target (HPA computes
+  `desiredReplicas = ceil(sum / threshold)`).
+- Per-service scrape failures are compensated only on the scale-down path
+  (missing samples are treated as `threshold`), preventing flapping when a
+  single replica is briefly unreachable.
+- The default scraped metric is `vllm:num_requests_waiting`. Any Prometheus
+  metric exposed on the workspace `Service` works (use a metric family name
+  identical to what `/metrics` exposes).
+
+#### Option 1: Auto-provision via InferenceSet annotations
+
+Annotations under the `scaledobject.kaito.sh/` prefix configure the auto-provision
+controller. When `auto-provision=true` and the configuration is valid, the
+controller creates a `ScaledObject` named after the `InferenceSet` (and keeps
+it in sync on annotation updates).
+
+| Annotation | Required | Default | Description |
+|---|---|---|---|
+| `scaledobject.kaito.sh/auto-provision` | yes | – | Must be `"true"` to enable auto-provisioning. |
+| `scaledobject.kaito.sh/threshold` | yes | – | Per-replica target value passed to the trigger. Non-negative integer. |
+| `scaledobject.kaito.sh/metricName` | no | `vllm:num_requests_waiting` | Prometheus metric family name to scrape from each pod. |
+| `scaledobject.kaito.sh/min-replicas` | no | `1` | Minimum replica count. Values `<= 1` collapse to `1`. |
+| `scaledobject.kaito.sh/max-replicas` | no | derived from `spec.nodeCountLimit` | Maximum replica count. When set, must be `> 1` and `>= min-replicas`; otherwise the controller skips reconciling and emits an `InvalidReplicaRange` warning event. If absent, auto-provisioning requires `spec.nodeCountLimit` to be set. |
 
 ```bash
 cat <<EOF | kubectl apply -f -
@@ -111,19 +138,85 @@ spec:
 EOF
 ```
 
- - In just a few seconds, the KEDA Kaito Scaler will automatically create the `scaledobject` and `hpa` objects. After a few minutes, once the inference pod is running, the KEDA Kaito Scaler will begin scraping metric values from the inference pod, and the status of the `scaledobject` and `hpa` objects will be marked as ready.
+In a few seconds the auto-provision controller creates a managed `ScaledObject`,
+and KEDA in turn creates the HPA. Once the inference pods are up and serving
+metrics, both objects flip to `READY=True`:
 
 ```bash
 # kubectl get scaledobject
-NAME           SCALETARGETKIND                  SCALETARGETNAME   MIN   MAX   READY   ACTIVE    FALLBACK   PAUSED   TRIGGERS   AUTHENTICATIONS           AGE
-phi-4          kaito.sh/v1alpha1.InferenceSet   phi-4             1     5     True    True     False      False    external   keda-kaito-scaler-creds   10m
+NAME    SCALETARGETKIND                  SCALETARGETNAME   MIN   MAX   READY   ACTIVE   FALLBACK   PAUSED   TRIGGERS   AUTHENTICATIONS           AGE
+phi-4   kaito.sh/v1alpha1.InferenceSet   phi-4             1     5     True    True     False      False    external   keda-kaito-scaler-creds   10m
 
 # kubectl get hpa
-NAME                    REFERENCE                   TARGETS      MINPODS   MAXPODS   REPLICAS   AGE
-keda-hpa-phi-4          InferenceSet/phi-4          0/10 (avg)   1         5         1          11m
+NAME             REFERENCE            TARGETS      MINPODS   MAXPODS   REPLICAS   AGE
+keda-hpa-phi-4   InferenceSet/phi-4   0/10 (avg)   1         5         1          11m
 ```
 
-That's it! Your KAITO workloads will now automatically scale based on the number of waiting inference requests (`vllm:num_requests_waiting`).
+#### Option 2: Manage the ScaledObject yourself
+
+If you prefer to author the `ScaledObject` directly (e.g. to plug in custom
+scaling policies or additional triggers), point an `external` trigger at the
+keda-kaito-scaler service and reuse the chart-installed
+`ClusterTriggerAuthentication` for mTLS.
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: phi-4
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: kaito.sh/v1alpha1
+    kind: InferenceSet
+    name: phi-4
+  minReplicaCount: 1
+  maxReplicaCount: 5
+  triggers:
+    - type: external
+      name: keda-kaito-scaler
+      metricType: AverageValue
+      authenticationRef:
+        kind: ClusterTriggerAuthentication
+        name: keda-kaito-scaler-creds
+      metadata:
+        # Required
+        scalerAddress: "keda-kaito-scaler-svc.keda.svc.cluster.local:10450"
+        inferenceSetName: phi-4
+        inferenceSetNamespace: default
+        metricName: "vllm:num_requests_waiting"
+        threshold: "10"
+
+        # Optional — defaults shown below match Kaito's current vLLM exposure
+        # (Workspace ClusterIP Service on port 80, plain HTTP). Override only
+        # if you have customized the inference server.
+        # metricProtocol: "http"     # http | https
+        # metricPort: "80"
+        # metricPath: "/metrics"
+        # scrapeTimeout: "3s"
+```
+
+The trigger metadata fields map 1:1 to the scaler's gRPC payload:
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `scalerAddress` | yes | – | Used by KEDA to dial the scaler. Format: `keda-kaito-scaler-svc.<scaler-namespace>.svc.cluster.local:10450`. |
+| `inferenceSetName` | yes | – | Target `InferenceSet` name. |
+| `inferenceSetNamespace` | yes | – | Target `InferenceSet` namespace. May differ from the `ScaledObject` namespace; a single keda-kaito-scaler instance serves all namespaces in the cluster. |
+| `metricName` | yes | – | Prometheus metric family name exposed by each workspace pod. |
+| `threshold` | yes | – | Per-replica target (float). HPA: `desired = ceil(sum / threshold)`. |
+| `metricProtocol` | no | `http` | `http` or `https`. |
+| `metricPort` | no | `80` | Workspace `Service` port. |
+| `metricPath` | no | `/metrics` | HTTP path of the Prometheus endpoint. |
+| `scrapeTimeout` | no | `3s` | Per-service scrape timeout (Go duration). |
+
+> **metricType must be `AverageValue`.** The scaler returns the cluster-wide
+> sum of the metric, so HPA divides by `threshold` (per-replica target) to get
+> the desired replica count. Using `Value` would couple desired replicas to the
+> current replica count and break scale-from/to-1 transitions.
+
+That's it! Your KAITO workloads will now automatically scale based on the
+configured metric (default: `vllm:num_requests_waiting`).
 
 ## Release Process
 

--- a/cmd/app/manager.go
+++ b/cmd/app/manager.go
@@ -180,7 +180,7 @@ func Run(opts *options.KedaKaitoScalerOptions) error {
 	// listening, so the manager alone drives the full lifecycle.
 	lo.Must0(mgr.Add(scaler.NewRunnable(scaler.ServerConfig{
 		Port:                 opts.GrpcPort,
-		Service:              scaler.NewKaitoScaler(mgr.GetClient(), metrics.NewServiceMetricsScraper(mgr.GetClient()), metrics.NewAverageAggregator()),
+		Service:              scaler.NewKaitoScaler(mgr.GetClient(), metrics.NewServiceMetricsScraper(mgr.GetClient()), metrics.NewSumAggregator()),
 		GetServerCertificate: cert.NewServerCertLoader(secretLister, opts.WorkingNamespace, opts.ScalerServerSecretName, ServerCert, ServerKey),
 		LoadRootCAs:          cert.NewRootCAsLoader(secretLister, opts.WorkingNamespace, opts.ScalerClientSecretName, CACert),
 		ServerCertReady:      serverCertReady,

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
-	"github.com/kaito-project/kaito/pkg/utils/inferenceset"
 	"github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	"golang.org/x/time/rate"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -45,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kaito-project/keda-kaito-scaler/pkg/scaler"
+	"github.com/kaito-project/keda-kaito-scaler/pkg/util/inferenceset"
 )
 
 const (
@@ -52,12 +52,17 @@ const (
 	AnnotationKeyMinReplicas   = "scaledobject.kaito.sh/min-replicas"
 	AnnotationKeyMaxReplicas   = "scaledobject.kaito.sh/max-replicas"
 	AnnotationKeyThreshold     = "scaledobject.kaito.sh/threshold"
+	AnnotationKeyMetricName    = "scaledobject.kaito.sh/metricName"
 
 	AnnotationKeyManagedBy = "scaledobject.kaito.sh/managed-by"
 	InferenceSet           = "InferenceSet"
 
 	inferenceSetAPIVersion = "kaito.sh/v1alpha1"
 	requeueInterval        = 5 * time.Second
+
+	// defaultMetricName is the metric scraped from each vLLM inference pod when
+	// the user does not override it via the metricName annotation.
+	defaultMetricName = "vllm:num_requests_waiting"
 )
 
 // watchedAnnotations are the annotations whose changes should trigger a
@@ -67,6 +72,7 @@ var watchedAnnotations = []string{
 	AnnotationKeyMinReplicas,
 	AnnotationKeyMaxReplicas,
 	AnnotationKeyThreshold,
+	AnnotationKeyMetricName,
 }
 
 type Controller struct {
@@ -112,13 +118,14 @@ func (c *Controller) Reconcile(ctx context.Context, is *kaitov1alpha1.InferenceS
 		return reconcile.Result{}, nil
 	}
 	threshold := is.Annotations[AnnotationKeyThreshold]
+	metricName := resolveMetricName(is.Annotations)
 
 	managedScaledObjects, err := c.listManagedScaledObjects(ctx, is)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, c.syncScaledObjects(ctx, is, managedScaledObjects, minReplicas, maxReplicas, threshold)
+	return reconcile.Result{}, c.syncScaledObjects(ctx, is, managedScaledObjects, minReplicas, maxReplicas, threshold, metricName)
 }
 
 // resolveMaxReplicas computes the max replicas for the ScaledObject. When
@@ -185,12 +192,12 @@ func (c *Controller) listManagedScaledObjects(ctx context.Context, is *kaitov1al
 
 // syncScaledObjects creates, updates, or deduplicates managed ScaledObjects so
 // that exactly one matches the desired spec.
-func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.InferenceSet, existing []v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold string) error {
+func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.InferenceSet, existing []v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold, metricName string) error {
 	switch len(existing) {
 	case 0:
-		return c.Create(ctx, c.buildScaledObject(is, minReplicas, maxReplicas, threshold))
+		return c.Create(ctx, c.buildScaledObject(is, minReplicas, maxReplicas, threshold, metricName))
 	case 1:
-		return c.updateScaledObject(ctx, is, &existing[0], minReplicas, maxReplicas, threshold)
+		return c.updateScaledObject(ctx, is, &existing[0], minReplicas, maxReplicas, threshold, metricName)
 	default:
 		// Keep the oldest one, delete the rest, then reconcile the kept one to
 		// the desired spec so it does not go stale after annotation changes.
@@ -202,11 +209,11 @@ func (c *Controller) syncScaledObjects(ctx context.Context, is *kaitov1alpha1.In
 				return err
 			}
 		}
-		return c.updateScaledObject(ctx, is, &existing[0], minReplicas, maxReplicas, threshold)
+		return c.updateScaledObject(ctx, is, &existing[0], minReplicas, maxReplicas, threshold, metricName)
 	}
 }
 
-func (c *Controller) buildScaledObject(is *kaitov1alpha1.InferenceSet, minReplicas, maxReplicas int, threshold string) *v1alpha1.ScaledObject {
+func (c *Controller) buildScaledObject(is *kaitov1alpha1.InferenceSet, minReplicas, maxReplicas int, threshold, metricName string) *v1alpha1.ScaledObject {
 	return &v1alpha1.ScaledObject{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      is.Name,
@@ -236,12 +243,12 @@ func (c *Controller) buildScaledObject(is *kaitov1alpha1.InferenceSet, minReplic
 			},
 			MinReplicaCount: ptr.To(int32(minReplicas)),
 			MaxReplicaCount: ptr.To(int32(maxReplicas)),
-			Triggers:        getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold),
+			Triggers:        getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold, metricName),
 		},
 	}
 }
 
-func (c *Controller) updateScaledObject(ctx context.Context, is *kaitov1alpha1.InferenceSet, so *v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold string) error {
+func (c *Controller) updateScaledObject(ctx context.Context, is *kaitov1alpha1.InferenceSet, so *v1alpha1.ScaledObject, minReplicas, maxReplicas int, threshold, metricName string) error {
 	updated := false
 
 	if so.Spec.MinReplicaCount == nil || *so.Spec.MinReplicaCount != int32(minReplicas) {
@@ -254,7 +261,7 @@ func (c *Controller) updateScaledObject(ctx context.Context, is *kaitov1alpha1.I
 	}
 	if len(so.Spec.Triggers) == 0 {
 		// Restore triggers if they were removed (e.g., manual edit drift).
-		so.Spec.Triggers = getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold)
+		so.Spec.Triggers = getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold, metricName)
 		updated = true
 	} else {
 		if so.Spec.Triggers[0].Metadata == nil {
@@ -262,6 +269,10 @@ func (c *Controller) updateScaledObject(ctx context.Context, is *kaitov1alpha1.I
 		}
 		if so.Spec.Triggers[0].Metadata["threshold"] != threshold {
 			so.Spec.Triggers[0].Metadata["threshold"] = threshold
+			updated = true
+		}
+		if so.Spec.Triggers[0].Metadata[scaler.MetricNameInMetadata] != metricName {
+			so.Spec.Triggers[0].Metadata[scaler.MetricNameInMetadata] = metricName
 			updated = true
 		}
 	}
@@ -316,6 +327,16 @@ func resolveMinReplicas(annotations map[string]string) int {
 		}
 	}
 	return 1
+}
+
+// resolveMetricName returns the metric name configured via the metricName
+// annotation on the InferenceSet, falling back to defaultMetricName when
+// the annotation is absent or empty.
+func resolveMetricName(annotations map[string]string) string {
+	if name, ok := annotations[AnnotationKeyMetricName]; ok && name != "" {
+		return name
+	}
+	return defaultMetricName
 }
 
 func enableAutoProvisioning(inferenceSet *kaitov1alpha1.InferenceSet) bool {
@@ -408,28 +429,21 @@ func getDefaultHorizontalPodAutoscalerConfig() *v1alpha1.HorizontalPodAutoscaler
 	}
 }
 
-func getDefaultKedaKaitoScalerTriggers(inferenceSetName, inferenceSetNamespace, scalerNamespace, threshold string) []v1alpha1.ScaleTriggers {
+func getDefaultKedaKaitoScalerTriggers(inferenceSetName, inferenceSetNamespace, scalerNamespace, threshold, metricName string) []v1alpha1.ScaleTriggers {
+	// metricProtocol/metricPort/metricPath/scrapeTimeout are intentionally
+	// omitted: the scaler-side parseScalerMetadata fills them with defaults
+	// matching Kaito's vLLM exposure (http on Service port 80, /metrics, 3s),
+	// so we only keep keys that the scaler cannot infer on its own.
 	return []v1alpha1.ScaleTriggers{
 		{
 			Type: "external",
 			Name: scaler.ScalerName,
 			Metadata: map[string]string{
-				"scalerName":                           scaler.ScalerName,
 				"threshold":                            threshold,
 				scaler.InferenceSetNameInMetadata:      inferenceSetName,
 				scaler.InferenceSetNamespaceInMetadata: inferenceSetNamespace,
 				scaler.ScalerAddressInMetadata:         fmt.Sprintf("keda-kaito-scaler-svc.%s.svc.cluster.local:%d", scalerNamespace, 10450),
-				scaler.MetricNameInMetadata:            "vllm:num_requests_waiting",
-				// Kaito creates a ClusterIP Service per workspace that exposes the
-				// vLLM inference server on spec.ports[name="http"] with Port=80 and
-				// TargetPort=consts.PortInferenceServer (5000). The server currently
-				// speaks plain HTTP (no TLS), so the scaler scrapes /metrics over
-				// http://<svc>:80. The protocol is kept configurable here so that
-				// https can be used in the future if Kaito enables TLS.
-				scaler.MetricProtocolInMetadata: "http",
-				scaler.MetricPortInMetadata:     "80",
-				scaler.MetricPathInMetadata:     "/metrics",
-				scaler.ScrapeTimeoutInMetadata:  "5s",
+				scaler.MetricNameInMetadata:            metricName,
 			},
 			AuthenticationRef: &v1alpha1.AuthenticationRef{
 				Name: "keda-kaito-scaler-creds",

--- a/pkg/controllers/autoprovision/auto_provision_controller_test.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller_test.go
@@ -89,7 +89,7 @@ func TestGetDefaultKedaKaitoScalerTriggers(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			triggers := getDefaultKedaKaitoScalerTriggers(tt.inferenceSetName, tt.inferenceSetNamespace, tt.scalerNamespace, tt.threshold)
+			triggers := getDefaultKedaKaitoScalerTriggers(tt.inferenceSetName, tt.inferenceSetNamespace, tt.scalerNamespace, tt.threshold, defaultMetricName)
 
 			// Check trigger count
 			assert.Equal(t, tt.expectedTriggerCount, len(triggers))
@@ -109,16 +109,17 @@ func TestGetDefaultKedaKaitoScalerTriggers(t *testing.T) {
 
 				// Check metadata
 				assert.NotNil(t, trigger.Metadata)
-				assert.Equal(t, "keda-kaito-scaler", trigger.Metadata["scalerName"])
 				assert.Equal(t, tt.threshold, trigger.Metadata["threshold"])
 				assert.Equal(t, tt.inferenceSetName, trigger.Metadata[scaler.InferenceSetNameInMetadata])
 				assert.Equal(t, tt.inferenceSetNamespace, trigger.Metadata[scaler.InferenceSetNamespaceInMetadata])
 				assert.Equal(t, fmt.Sprintf("keda-kaito-scaler-svc.%s.svc.cluster.local:%d", tt.scalerNamespace, 10450), trigger.Metadata[scaler.ScalerAddressInMetadata])
 				assert.Equal(t, "vllm:num_requests_waiting", trigger.Metadata[scaler.MetricNameInMetadata])
-				assert.Equal(t, "http", trigger.Metadata[scaler.MetricProtocolInMetadata])
-				assert.Equal(t, "80", trigger.Metadata[scaler.MetricPortInMetadata])
-				assert.Equal(t, "/metrics", trigger.Metadata[scaler.MetricPathInMetadata])
-				assert.Equal(t, "5s", trigger.Metadata[scaler.ScrapeTimeoutInMetadata])
+				// Optional scrape settings (protocol/port/path/timeout) are intentionally
+				// omitted from the trigger metadata so the scaler can apply its defaults.
+				assert.NotContains(t, trigger.Metadata, scaler.MetricProtocolInMetadata)
+				assert.NotContains(t, trigger.Metadata, scaler.MetricPortInMetadata)
+				assert.NotContains(t, trigger.Metadata, scaler.MetricPathInMetadata)
+				assert.NotContains(t, trigger.Metadata, scaler.ScrapeTimeoutInMetadata)
 			}
 		})
 	}
@@ -130,23 +131,18 @@ func TestGetDefaultKedaKaitoScalerTriggers_MetadataKeys(t *testing.T) {
 	scalerNamespace := "kaito-workspace"
 	threshold := "10"
 
-	triggers := getDefaultKedaKaitoScalerTriggers(inferenceSetName, inferenceSetNamespace, scalerNamespace, threshold)
+	triggers := getDefaultKedaKaitoScalerTriggers(inferenceSetName, inferenceSetNamespace, scalerNamespace, threshold, defaultMetricName)
 
 	assert.Equal(t, 1, len(triggers))
 	trigger := triggers[0]
 
 	// Verify all expected metadata keys are present
 	expectedKeys := []string{
-		"scalerName",
 		"threshold",
 		scaler.InferenceSetNameInMetadata,
 		scaler.InferenceSetNamespaceInMetadata,
 		scaler.ScalerAddressInMetadata,
 		scaler.MetricNameInMetadata,
-		scaler.MetricProtocolInMetadata,
-		scaler.MetricPortInMetadata,
-		scaler.MetricPathInMetadata,
-		scaler.ScrapeTimeoutInMetadata,
 	}
 
 	for _, key := range expectedKeys {

--- a/pkg/metrics/aggregator.go
+++ b/pkg/metrics/aggregator.go
@@ -22,31 +22,44 @@ import (
 
 // Aggregator reduces the per-service values inside a MetricSnapshot to the
 // single metric value that KEDA consumes.
+//
+// The returned value is meant to be paired with HPA's "AverageValue" target
+// type, where the threshold passed by KEDA represents the per-replica desired
+// load. HPA then computes desiredReplicas = ceil(value / threshold), so the
+// aggregator must return the *total* (sum) load across all services.
 type Aggregator interface {
-	Aggregate(snapshot *MetricSnapshot, metricName string, threshold int64) (float64, error)
+	Aggregate(snapshot *MetricSnapshot, metricName string, threshold float64) (float64, error)
 }
 
-// AverageAggregator averages a metric across every service that belongs to an
+// SumAggregator sums a metric across every service that belongs to an
 // InferenceSet, compensating for services that could not be scraped in order
-// to avoid flapping:
+// to avoid flapping.
 //
-//   - scale-up direction (average of successful samples >= threshold): missing
+// Compensation strategy (mirrors how K8s HPA's ReplicaCalculator handles
+// missing pods for Pods/Resource metrics, which it does NOT do for External
+// metrics – so we do it ourselves):
+//
+//   - scale-up direction (avg of successful samples >= threshold): missing
 //     services contribute 0 (their absence must not prevent scale-up).
-//   - scale-down direction (average of successful samples < threshold): missing
+//   - scale-down direction (avg of successful samples <  threshold): missing
 //     services contribute the threshold value (their absence must not trigger
 //     further scale-down).
 //
 // If no service could be scraped successfully, the combined per-service errors
 // are returned.
-type AverageAggregator struct{}
+//
+// Negative aggregated values are clamped to 0; KEDA's external_scaler client
+// otherwise silently treats negative MetricValueFloat as 0 by falling back to
+// the deprecated int64 MetricValue, which would mask bugs in the scraper.
+type SumAggregator struct{}
 
-// NewAverageAggregator returns a ready-to-use AverageAggregator.
-func NewAverageAggregator() *AverageAggregator {
-	return &AverageAggregator{}
+// NewSumAggregator returns a ready-to-use SumAggregator.
+func NewSumAggregator() *SumAggregator {
+	return &SumAggregator{}
 }
 
 // Aggregate implements Aggregator.
-func (a *AverageAggregator) Aggregate(snapshot *MetricSnapshot, metricName string, threshold int64) (float64, error) {
+func (a *SumAggregator) Aggregate(snapshot *MetricSnapshot, metricName string, threshold float64) (float64, error) {
 	if snapshot == nil {
 		return 0, fmt.Errorf("metric snapshot is nil")
 	}
@@ -84,13 +97,17 @@ func (a *AverageAggregator) Aggregate(snapshot *MetricSnapshot, metricName strin
 	// Compensate for missing services only in the scale-down direction.
 	if successCount != total {
 		avgSuccess := sum / float64(successCount)
-		if avgSuccess < float64(threshold) {
-			sum += float64(threshold) * float64(total-successCount)
+		if avgSuccess < threshold {
+			sum += threshold * float64(total-successCount)
 		}
 	}
 
-	avg := sum / float64(total)
-	klog.V(4).Infof("aggregated metric %q for inferenceset %s: avg=%f sum=%f success=%d total=%d threshold=%d",
-		metricName, snapshot.InferenceSet, avg, sum, successCount, total, threshold)
-	return avg, nil
+	if sum < 0 {
+		klog.Warningf("aggregated metric %q for inferenceset %s is negative (%f); clamping to 0", metricName, snapshot.InferenceSet, sum)
+		sum = 0
+	}
+
+	klog.V(4).Infof("aggregated metric %q for inferenceset %s: sum=%f success=%d total=%d threshold=%f",
+		metricName, snapshot.InferenceSet, sum, successCount, total, threshold)
+	return sum, nil
 }

--- a/pkg/metrics/aggregator_test.go
+++ b/pkg/metrics/aggregator_test.go
@@ -21,14 +21,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestAverageAggregator_Aggregate(t *testing.T) {
-	agg := NewAverageAggregator()
+func TestSumAggregator_Aggregate(t *testing.T) {
+	agg := NewSumAggregator()
 
 	tests := []struct {
 		name       string
 		snapshot   *MetricSnapshot
 		metricName string
-		threshold  int64
+		threshold  float64
 		wantValue  float64
 		wantErr    bool
 	}{
@@ -46,7 +46,7 @@ func TestAverageAggregator_Aggregate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "average over all successful services",
+			name: "sum over all successful services",
 			snapshot: &MetricSnapshot{
 				Services: []ServiceMetrics{
 					{Name: "a", Metrics: map[string]float64{"m": 10}},
@@ -55,7 +55,7 @@ func TestAverageAggregator_Aggregate(t *testing.T) {
 			},
 			metricName: "m",
 			threshold:  5,
-			wantValue:  20,
+			wantValue:  40,
 		},
 		{
 			name: "scale-down missing service compensated with threshold",
@@ -67,8 +67,8 @@ func TestAverageAggregator_Aggregate(t *testing.T) {
 			},
 			metricName: "m",
 			threshold:  10,
-			// success avg=2 (< threshold 10 => scale-down). sum becomes 2+10=12, total=2 => 6
-			wantValue: 6,
+			// success avg=2 (< threshold 10 => scale-down). sum becomes 2+10=12.
+			wantValue: 12,
 		},
 		{
 			name: "scale-up missing service not compensated",
@@ -80,8 +80,8 @@ func TestAverageAggregator_Aggregate(t *testing.T) {
 			},
 			metricName: "m",
 			threshold:  10,
-			// success avg=20 (>= threshold 10 => scale-up). sum stays 20, total=2 => 10
-			wantValue: 10,
+			// success avg=20 (>= threshold 10 => scale-up). sum stays 20.
+			wantValue: 20,
 		},
 		{
 			name: "metric name missing on a service is treated as scrape failure",
@@ -93,8 +93,20 @@ func TestAverageAggregator_Aggregate(t *testing.T) {
 			},
 			metricName: "m",
 			threshold:  10,
-			// success count=1 avg=4 < threshold. sum=4+10=14, total=2 => 7
-			wantValue: 7,
+			// success count=1 avg=4 < threshold. sum=4+10=14.
+			wantValue: 14,
+		},
+		{
+			name: "negative aggregated value is clamped to zero",
+			snapshot: &MetricSnapshot{
+				Services: []ServiceMetrics{
+					{Name: "a", Metrics: map[string]float64{"m": -5}},
+					{Name: "b", Metrics: map[string]float64{"m": -3}},
+				},
+			},
+			metricName: "m",
+			threshold:  10,
+			wantValue:  0,
 		},
 		{
 			name: "all services failed returns error",

--- a/pkg/metrics/service_metrics_scraper.go
+++ b/pkg/metrics/service_metrics_scraper.go
@@ -22,13 +22,14 @@ import (
 	"time"
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
-	"github.com/kaito-project/kaito/pkg/utils/inferenceset"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kaito-project/keda-kaito-scaler/pkg/util/inferenceset"
 )
 
 // +kubebuilder:rbac:groups="kaito.sh",resources=inferencesets,verbs=get;list;watch

--- a/pkg/scaler/scaler.go
+++ b/pkg/scaler/scaler.go
@@ -34,7 +34,6 @@ const (
 	ScalerName = "keda-kaito-scaler"
 
 	// Metadata keys
-	ScalerNameKeyInMetadata         = "scalerName"
 	InferenceSetNameInMetadata      = "inferenceSetName"
 	InferenceSetNamespaceInMetadata = "inferenceSetNamespace"
 	ScalerAddressInMetadata         = "scalerAddress"
@@ -44,6 +43,15 @@ const (
 	MetricPortInMetadata            = "metricPort"
 	MetricPathInMetadata            = "metricPath"
 	ScrapeTimeoutInMetadata         = "scrapeTimeout"
+
+	// Defaults applied when the corresponding metadata key is omitted. Only
+	// inferenceSetName/inferenceSetNamespace/metricName/threshold remain
+	// mandatory; everything else falls back to a sensible value matching
+	// Kaito's current vLLM exposure conventions.
+	defaultMetricProtocol = "http"
+	defaultMetricPort     = "80"
+	defaultMetricPath     = "/metrics"
+	defaultScrapeTimeout  = 3 * time.Second
 )
 
 // Config is the parsed scaler metadata payload sent by KEDA for every request.
@@ -55,7 +63,7 @@ type Config struct {
 	MetricPort            string
 	MetricPath            string
 	ScrapeTimeout         time.Duration
-	Threshold             int64
+	Threshold             float64
 }
 
 // scrapeConfig projects the subset of Config needed by the metrics Scraper.
@@ -116,8 +124,12 @@ func (e *KaitoScaler) IsActive(ctx context.Context, sor *externalscaler.ScaledOb
 }
 
 func (e *KaitoScaler) StreamIsActive(sor *externalscaler.ScaledObjectRef, server externalscaler.ExternalScaler_StreamIsActiveServer) error {
-	// do nothing for stream mode
-	return nil
+	// keda-kaito-scaler does not support KEDA's external-push trigger. Returning
+	// Unimplemented immediately surfaces a misconfiguration to the user, instead
+	// of letting the KEDA push client get stuck in an infinite reconnect loop
+	// (which is what would happen if we returned nil – the client treats nil as
+	// io.EOF and keeps re-establishing the stream).
+	return status.Error(codes.Unimplemented, "keda-kaito-scaler does not support push mode; use the regular external trigger")
 }
 
 func (e *KaitoScaler) GetMetricSpec(_ context.Context, sor *externalscaler.ScaledObjectRef) (*externalscaler.GetMetricSpecResponse, error) {
@@ -129,7 +141,10 @@ func (e *KaitoScaler) GetMetricSpec(_ context.Context, sor *externalscaler.Scale
 	return &externalscaler.GetMetricSpecResponse{
 		MetricSpecs: []*externalscaler.MetricSpec{{
 			MetricName: scalerConfig.MetricName,
-			TargetSize: scalerConfig.Threshold,
+			// TargetSize (int64) is deprecated in the externalscaler proto in favor
+			// of TargetSizeFloat. Using the float field also lets users express
+			// sub-integer per-replica thresholds (e.g. 0.5 QPS).
+			TargetSizeFloat: scalerConfig.Threshold,
 		}},
 	}, nil
 }
@@ -175,63 +190,65 @@ func (e *KaitoScaler) GetMetrics(ctx context.Context, gmr *externalscaler.GetMet
 }
 
 func parseScalerMetadata(sor *externalscaler.ScaledObjectRef, metricName string) (*Config, error) {
-	if scalerName, ok := sor.ScalerMetadata[ScalerNameKeyInMetadata]; !ok || scalerName != ScalerName {
-		return nil, status.Error(codes.InvalidArgument, "scaler name must be keda-kaito-scaler")
-	}
+	md := sor.ScalerMetadata
 
-	inferenceSetName, ok := sor.ScalerMetadata[InferenceSetNameInMetadata]
-	if !ok || inferenceSetName == "" {
+	// Mandatory: identifies the workload to scrape.
+	inferenceSetName := md[InferenceSetNameInMetadata]
+	if inferenceSetName == "" {
 		return nil, status.Error(codes.InvalidArgument, "inference set name must be specified")
 	}
-
-	inferenceSetNamespace, ok := sor.ScalerMetadata[InferenceSetNamespaceInMetadata]
-	if !ok || inferenceSetNamespace == "" {
+	inferenceSetNamespace := md[InferenceSetNamespaceInMetadata]
+	if inferenceSetNamespace == "" {
 		return nil, status.Error(codes.InvalidArgument, "inference set namespace must be specified")
 	}
 
+	// metricName: GetMetrics receives it via the gRPC request (after KEDA strips
+	// the sX- prefix); GetMetricSpec/IsActive pass "" and we fall back to
+	// metadata. Either way it must end up non-empty.
 	if metricName == "" {
-		name, ok := sor.ScalerMetadata[MetricNameInMetadata]
-		if !ok || name == "" {
-			return nil, status.Error(codes.InvalidArgument, "metric name must be specified")
-		}
-		metricName = name
+		metricName = md[MetricNameInMetadata]
+	}
+	if metricName == "" {
+		return nil, status.Error(codes.InvalidArgument, "metric name must be specified")
 	}
 
-	metricProtocol, ok := sor.ScalerMetadata[MetricProtocolInMetadata]
-	if !ok || metricProtocol == "" {
-		return nil, status.Error(codes.InvalidArgument, "metric protocol must be specified")
+	// Threshold is the per-replica target; required so users always make an
+	// explicit scaling decision.
+	thresholdStr := md[ThresholdInMetadata]
+	if thresholdStr == "" {
+		return nil, status.Error(codes.InvalidArgument, "threshold must be specified")
+	}
+	threshold, err := strconv.ParseFloat(thresholdStr, 64)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, "threshold must be a valid number")
+	}
+
+	// Optional scrape settings: default to Kaito's current vLLM exposure
+	// (http on workspace Service port 80, /metrics, 3s timeout).
+	metricProtocol := md[MetricProtocolInMetadata]
+	if metricProtocol == "" {
+		metricProtocol = defaultMetricProtocol
 	} else if metricProtocol != "http" && metricProtocol != "https" {
 		return nil, status.Error(codes.InvalidArgument, "metric protocol must be either http or https")
 	}
 
-	metricPort, ok := sor.ScalerMetadata[MetricPortInMetadata]
-	if !ok || metricPort == "" {
-		return nil, status.Error(codes.InvalidArgument, "metric port must be specified")
+	metricPort := md[MetricPortInMetadata]
+	if metricPort == "" {
+		metricPort = defaultMetricPort
 	}
 
-	metricPath, ok := sor.ScalerMetadata[MetricPathInMetadata]
-	if !ok || metricPath == "" {
-		return nil, status.Error(codes.InvalidArgument, "metric path must be specified")
+	metricPath := md[MetricPathInMetadata]
+	if metricPath == "" {
+		metricPath = defaultMetricPath
 	}
 
-	scrapeTimeoutStr, ok := sor.ScalerMetadata[ScrapeTimeoutInMetadata]
-	if !ok || scrapeTimeoutStr == "" {
-		return nil, status.Error(codes.InvalidArgument, "scrape timeout must be specified")
-	}
-
-	scrapeTimeout, err := time.ParseDuration(scrapeTimeoutStr)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "scrape timeout must be a valid duration")
-	}
-
-	thresholdStr, ok := sor.ScalerMetadata[ThresholdInMetadata]
-	if !ok || thresholdStr == "" {
-		return nil, status.Error(codes.InvalidArgument, "threshold must be specified")
-	}
-
-	threshold, err := strconv.ParseInt(thresholdStr, 10, 64)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "threshold must be a valid integer")
+	scrapeTimeout := defaultScrapeTimeout
+	if s := md[ScrapeTimeoutInMetadata]; s != "" {
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, "scrape timeout must be a valid duration")
+		}
+		scrapeTimeout = d
 	}
 
 	return &Config{

--- a/pkg/scaler/scaler_test.go
+++ b/pkg/scaler/scaler_test.go
@@ -54,11 +54,11 @@ type stubAggregator struct {
 	err       error
 	gotMetric string
 	gotSnap   *metrics.MetricSnapshot
-	threshold int64
+	threshold float64
 	callCount int
 }
 
-func (a *stubAggregator) Aggregate(snap *metrics.MetricSnapshot, metricName string, threshold int64) (float64, error) {
+func (a *stubAggregator) Aggregate(snap *metrics.MetricSnapshot, metricName string, threshold float64) (float64, error) {
 	a.callCount++
 	a.gotSnap = snap
 	a.gotMetric = metricName
@@ -75,7 +75,6 @@ func newFakeClient(t *testing.T, objs ...client.Object) client.Client {
 
 func newValidScalerMetadata() map[string]string {
 	return map[string]string{
-		ScalerNameKeyInMetadata:         ScalerName,
 		InferenceSetNameInMetadata:      "is1",
 		InferenceSetNamespaceInMetadata: "ns1",
 		MetricNameInMetadata:            "vllm:num_requests_waiting",
@@ -124,8 +123,6 @@ func TestParseScalerMetadata(t *testing.T) {
 		wantErr    bool
 	}{
 		{name: "valid"},
-		{name: "missing scaler name", mutate: func(m map[string]string) { delete(m, ScalerNameKeyInMetadata) }, wantErr: true},
-		{name: "wrong scaler name", mutate: func(m map[string]string) { m[ScalerNameKeyInMetadata] = "other" }, wantErr: true},
 		{name: "missing inference set name", mutate: func(m map[string]string) { delete(m, InferenceSetNameInMetadata) }, wantErr: true},
 		{name: "missing inference set namespace", mutate: func(m map[string]string) { delete(m, InferenceSetNamespaceInMetadata) }, wantErr: true},
 		{name: "missing metric name", mutate: func(m map[string]string) { delete(m, MetricNameInMetadata) }, wantErr: true},
@@ -133,6 +130,12 @@ func TestParseScalerMetadata(t *testing.T) {
 		{name: "invalid timeout", mutate: func(m map[string]string) { m[ScrapeTimeoutInMetadata] = "abc" }, wantErr: true},
 		{name: "invalid threshold", mutate: func(m map[string]string) { m[ThresholdInMetadata] = "abc" }, wantErr: true},
 		{name: "metric name override", mutate: func(m map[string]string) { delete(m, MetricNameInMetadata) }, metricName: "override:metric"},
+		{name: "optional fields default when omitted", mutate: func(m map[string]string) {
+			delete(m, MetricProtocolInMetadata)
+			delete(m, MetricPortInMetadata)
+			delete(m, MetricPathInMetadata)
+			delete(m, ScrapeTimeoutInMetadata)
+		}},
 	}
 
 	for _, tt := range tests {
@@ -150,7 +153,7 @@ func TestParseScalerMetadata(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, "is1", cfg.InferenceSetName)
 			assert.Equal(t, "ns1", cfg.InferenceSetNamespace)
-			assert.Equal(t, int64(10), cfg.Threshold)
+			assert.Equal(t, float64(10), cfg.Threshold)
 			assert.Equal(t, 3*time.Second, cfg.ScrapeTimeout)
 			if tt.metricName != "" {
 				assert.Equal(t, tt.metricName, cfg.MetricName)
@@ -213,7 +216,7 @@ func TestKaitoScaler_GetMetricSpec(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, resp.MetricSpecs, 1)
 	assert.Equal(t, "vllm:num_requests_waiting", resp.MetricSpecs[0].MetricName)
-	assert.Equal(t, int64(10), resp.MetricSpecs[0].TargetSize)
+	assert.Equal(t, float64(10), resp.MetricSpecs[0].TargetSizeFloat)
 }
 
 func TestKaitoScaler_GetMetrics(t *testing.T) {
@@ -244,7 +247,7 @@ func TestKaitoScaler_GetMetrics(t *testing.T) {
 		assert.Equal(t, 3*time.Second, sc.gotCfg.Timeout)
 		assert.Equal(t, types.NamespacedName{Namespace: "ns1", Name: "is1"}, sc.gotIS)
 		assert.Equal(t, "vllm:num_requests_waiting", ag.gotMetric)
-		assert.Equal(t, int64(10), ag.threshold)
+		assert.Equal(t, float64(10), ag.threshold)
 		assert.Same(t, snap, ag.gotSnap)
 		assert.Equal(t, 1, ag.callCount)
 	})

--- a/pkg/util/inferenceset/inferenceset.go
+++ b/pkg/util/inferenceset/inferenceset.go
@@ -1,0 +1,54 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inferenceset
+
+import (
+	"context"
+	"fmt"
+
+	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// WorkspaceCreatedByInferenceSetLabel marks Workspaces created by an InferenceSet.
+// Value is the InferenceSet name.
+const WorkspaceCreatedByInferenceSetLabel = "inferenceset.kaito.sh/created-by"
+
+// ListWorkspaces lists Workspaces in iObj.Namespace created by the given InferenceSet.
+func ListWorkspaces(ctx context.Context, iObj *kaitov1alpha1.InferenceSet, kubeClient client.Client) (*kaitov1beta1.WorkspaceList, error) {
+	if iObj == nil {
+		return nil, fmt.Errorf("InferenceSet object is nil")
+	}
+
+	workspaceList := &kaitov1beta1.WorkspaceList{}
+	selector := labels.SelectorFromSet(labels.Set{
+		WorkspaceCreatedByInferenceSetLabel: iObj.Name,
+	})
+
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return true
+	}, func() error {
+		return kubeClient.List(ctx, workspaceList,
+			client.InNamespace(iObj.Namespace),
+			&client.MatchingLabelsSelector{Selector: selector},
+		)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return workspaceList, nil
+}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

1. Aggregation: average → sum. Renamed AverageAggregator to SumAggregator and switched to float64 thresholds. The aggregator now returns the total metric value across services (paired with HPA AverageValue, so HPA computes replicas via ceil(sum/threshold)). Negative results are clamped to 0. Manager wired to NewSumAggregator().

2. Scaler metadata simplification. Removed the redundant scalerName metadata key. Added defaults for metricProtocol=http, metricPort=80, metricPath=/metrics, scrapeTimeout=3s, so only inferenceSetName/Namespace, metricName, and threshold remain mandatory. Threshold is now float64; GetMetricSpec returns TargetSizeFloat (deprecating TargetSize).

3. StreamIsActive now returns Unimplemented instead of nil to fail fast on push-mode misconfig.

4. Auto-provision controller. New scaledobject.kaito.sh/metricName annotation (defaulting to vllm:num_requests_waiting); reconciler builds/updates triggers with the resolved metric name and drops the now-defaulted protocol/port/path/timeout fields. Switched import to local inferenceset.

5. New helper inferenceset.go (local ListWorkspaces).

6. Tests updated to new aggregator name, float thresholds, and metadata shape.

7. README expanded with the new metric semantics, default-metric override annotation, and clarified manual ScaledObject usage.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: