### PR TITLE
feat: update pooling interval from 30s to 15s(the same as hpa)

### DIFF
--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -63,6 +63,12 @@ const (
 	// defaultMetricName is the metric scraped from each vLLM inference pod when
 	// the user does not override it via the metricName annotation.
 	defaultMetricName = "vllm:num_requests_waiting"
+
+	// defaultPollingInterval is the interval (in seconds) at which KEDA polls
+	// the external scaler for metrics. Overrides KEDA's built-in default of 30s
+	// to give the autoscaler fresher signals for latency-sensitive inference
+	// workloads.
+	defaultPollingInterval = 15
 )
 
 // watchedAnnotations are the annotations whose changes should trigger a
@@ -241,6 +247,7 @@ func (c *Controller) buildScaledObject(is *kaitov1alpha1.InferenceSet, minReplic
 				APIVersion: inferenceSetAPIVersion,
 				Kind:       InferenceSet,
 			},
+			PollingInterval: ptr.To(int32(defaultPollingInterval)),
 			MinReplicaCount: ptr.To(int32(minReplicas)),
 			MaxReplicaCount: ptr.To(int32(maxReplicas)),
 			Triggers:        getDefaultKedaKaitoScalerTriggers(is.Name, is.Namespace, c.ScalerNamespace, threshold, metricName),

--- a/pkg/controllers/autoprovision/auto_provision_controller_test.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller_test.go
@@ -396,3 +396,57 @@ func TestResolveMaxReplicas(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildScaledObject(t *testing.T) {
+	const (
+		inferenceSetName      = "test-is"
+		inferenceSetNamespace = "default"
+		scalerNamespace       = "kaito-workspace"
+		threshold             = "10"
+		minReplicas           = 2
+		maxReplicas           = 5
+	)
+
+	is := &kaitov1alpha1.InferenceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      inferenceSetName,
+			Namespace: inferenceSetNamespace,
+			UID:       "test-uid",
+		},
+	}
+
+	ctrl := &Controller{ScalerNamespace: scalerNamespace}
+	so := ctrl.buildScaledObject(is, minReplicas, maxReplicas, threshold, defaultMetricName)
+
+	// Object meta
+	assert.Equal(t, inferenceSetName, so.Name)
+	assert.Equal(t, inferenceSetNamespace, so.Namespace)
+	assert.Equal(t, scaler.ScalerName, so.Annotations[AnnotationKeyManagedBy])
+	assert.Len(t, so.OwnerReferences, 1)
+	assert.Equal(t, InferenceSet, so.OwnerReferences[0].Kind)
+	assert.Equal(t, inferenceSetName, so.OwnerReferences[0].Name)
+
+	// PollingInterval defaults to 15s so KEDA polls the external scaler more
+	// frequently than its built-in 30s default.
+	assert.NotNil(t, so.Spec.PollingInterval)
+	assert.Equal(t, int32(defaultPollingInterval), *so.Spec.PollingInterval)
+	assert.Equal(t, int32(15), *so.Spec.PollingInterval)
+
+	// Replica bounds
+	assert.NotNil(t, so.Spec.MinReplicaCount)
+	assert.Equal(t, int32(minReplicas), *so.Spec.MinReplicaCount)
+	assert.NotNil(t, so.Spec.MaxReplicaCount)
+	assert.Equal(t, int32(maxReplicas), *so.Spec.MaxReplicaCount)
+
+	// Scale target
+	assert.NotNil(t, so.Spec.ScaleTargetRef)
+	assert.Equal(t, inferenceSetName, so.Spec.ScaleTargetRef.Name)
+	assert.Equal(t, InferenceSet, so.Spec.ScaleTargetRef.Kind)
+	assert.Equal(t, inferenceSetAPIVersion, so.Spec.ScaleTargetRef.APIVersion)
+
+	// Advanced HPA config and triggers wired in
+	assert.NotNil(t, so.Spec.Advanced)
+	assert.NotNil(t, so.Spec.Advanced.HorizontalPodAutoscalerConfig)
+	assert.Len(t, so.Spec.Triggers, 1)
+	assert.Equal(t, threshold, so.Spec.Triggers[0].Metadata["threshold"])
+}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
update pooling interval from 30s to 15s(the same as hpa)

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: