### PR TITLE
fix: use single scaledobject.kaito.sh/metrics YAML list annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ You can drive autoscaling in two ways:
 
 #### Option 1: Auto-provision (recommended)
 
-Adding the indexed `metricName/0` annotation enables auto-provisioning:
-keda-kaito-scaler builds and reconciles a `ScaledObject` whose KEDA
-`scalingModifiers` formula applies a conservative **AND** policy — scale up by
+Adding the `metrics` annotation (together with `auto-provision: "true"`) enables
+auto-provisioning: keda-kaito-scaler builds and reconciles a `ScaledObject` whose
+KEDA `scalingModifiers` formula applies a conservative **AND** policy — scale up by
 one replica only when *every* configured metric is above its
 up-threshold (and newly added pods are ready), scale down by one replica only
 when *every* metric is below its down-threshold, otherwise hold. Each scale
@@ -114,25 +114,34 @@ step is capped at ±1 replica per cooldown to protect expensive GPU capacity.
 Configuring a single metric is fully supported; it just yields a one-signal
 formula.
 
-All configuration lives under the `scaledobject.kaito.sh/` prefix. Per-metric
-keys are indexed with a `/{i}` suffix (`/0`, `/1`, ...); global keys are
-un-indexed. Any Prometheus metric name is accepted.
+The per-metric configuration lives in a single `scaledobject.kaito.sh/metrics`
+annotation, whose value is a YAML (or JSON) list — one entry per metric. Global
+settings stay as their own `scaledobject.kaito.sh/` annotations. Any Prometheus
+metric name is accepted.
 
-| Annotation (`scaledobject.kaito.sh/`) | Scope | Required | Default | Description |
-| --- | --- | --- | --- | --- |
-| `auto-provision` | global | yes | – | Must be `"true"` to enable auto-provisioning. |
-| `metricName/{i}` | per-metric | yes | – | Prometheus metric name for slot `i`. Presence of `metricName/0` enables auto-provisioning. |
-| `metricstype/{i}` | per-metric | yes | – | Aggregation for metric `i`: `gauge` → per-replica average across pods; `histogram` → per-pod quantile. Both are replica-count independent. |
-| `metricsource/{i}` | per-metric | no | `modelpod` | Where metric `i` is scraped. Only `modelpod` (the model-serving pods behind the `InferenceSet`'s workspace `Service`s) is supported. |
-| `upthreshold/{i}` | per-metric | yes | – | Scale-up threshold for metric `i` (float). |
-| `downthreshold/{i}` | per-metric | yes | – | Scale-down threshold for metric `i` (float). Must be `<= upthreshold/{i}`. |
-| `quantile/{i}` | per-metric | no | `0.95` | Target quantile in `(0, 1]` for `histogram` metrics; ignored for `gauge`. |
-| `combinepolicy` | global | no | `AND` | How per-metric conditions are combined. Only `AND` is currently supported. |
-| `evaluationwindow` | global | no | `60` | Scale-up stabilization window (seconds). |
-| `scaleupcooldown` | global | no | `300` | Minimum seconds between scale-up steps. |
-| `scaledowncooldown` | global | no | `300` | Minimum seconds between scale-down steps. |
-| `min-replicas` | global | no | `1` | Minimum replica count. Values `<= 1` collapse to `1`. |
-| `max-replicas` | global | no | derived from `spec.nodeCountLimit` | Maximum replica count. Must be `> 1` and `>= min-replicas`; if absent, `spec.nodeCountLimit` must be set. |
+Each entry in the `metrics` list accepts the following fields:
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `name` | yes | – | Prometheus metric name. |
+| `type` | yes | – | Aggregation: `gauge` → per-replica average across pods; `histogram` → per-pod quantile. Both are replica-count independent. |
+| `source` | no | `modelpod` | Where the metric is scraped. Only `modelpod` (the model-serving pods behind the `InferenceSet`'s workspace `Service`s) is supported. |
+| `upthreshold` | yes | – | Scale-up threshold (float). |
+| `downthreshold` | yes | – | Scale-down threshold (float). Must be `<= upthreshold`. |
+| `quantile` | no | `0.95` | Target quantile in `(0, 1]` for `histogram` metrics; ignored for `gauge`. |
+
+The remaining global annotations:
+
+| Annotation (`scaledobject.kaito.sh/`) | Required | Default | Description |
+| --- | --- | --- | --- |
+| `auto-provision` | yes | – | Must be `"true"` to enable auto-provisioning. |
+| `metrics` | yes | – | YAML/JSON list of metric entries (see fields above). At least one entry is required. |
+| `combinepolicy` | no | `AND` | How per-metric conditions are combined. Only `AND` is currently supported. |
+| `evaluationwindow` | no | `60` | Scale-up stabilization window (seconds). |
+| `scaleupcooldown` | no | `300` | Minimum seconds between scale-up steps. |
+| `scaledowncooldown` | no | `300` | Minimum seconds between scale-down steps. |
+| `min-replicas` | no | `1` | Minimum replica count. Values `<= 1` collapse to `1`. |
+| `max-replicas` | no | derived from `spec.nodeCountLimit` | Maximum replica count. Must be `> 1` and `>= min-replicas`; if absent, `spec.nodeCountLimit` must be set. |
 
 ##### Single-metric example
 
@@ -148,11 +157,12 @@ metadata:
   annotations:
     scaledobject.kaito.sh/auto-provision: "true"
 
-    # Metric 0: vLLM waiting-queue length (modelpod, gauge -> per-replica average)
-    scaledobject.kaito.sh/metricName/0: "vllm:num_requests_waiting"
-    scaledobject.kaito.sh/metricstype/0: "gauge"
-    scaledobject.kaito.sh/upthreshold/0: "5"
-    scaledobject.kaito.sh/downthreshold/0: "1"
+    # A single metric: vLLM waiting-queue length (modelpod, gauge -> per-replica average)
+    scaledobject.kaito.sh/metrics: |
+      - name: vllm:num_requests_waiting
+        type: gauge
+        upthreshold: 5
+        downthreshold: 1
   name: phi-4
   namespace: default
 spec:
@@ -278,18 +288,19 @@ metadata:
   annotations:
     scaledobject.kaito.sh/auto-provision: "true"
 
-    # Metric 0: vLLM waiting-queue length (modelpod, gauge -> per-replica average)
-    scaledobject.kaito.sh/metricName/0: "vllm:num_requests_waiting"
-    scaledobject.kaito.sh/metricstype/0: "gauge"
-    scaledobject.kaito.sh/upthreshold/0: "5"
-    scaledobject.kaito.sh/downthreshold/0: "1"
-
-    # Metric 1: p95 request queue time (modelpod, histogram -> quantile)
-    scaledobject.kaito.sh/metricName/1: "vllm:request_queue_time_seconds"
-    scaledobject.kaito.sh/metricstype/1: "histogram"
-    scaledobject.kaito.sh/upthreshold/1: "2.0"
-    scaledobject.kaito.sh/downthreshold/1: "0.5"
-    scaledobject.kaito.sh/quantile/1: "0.95"
+    # Two metrics combined under the conservative AND policy:
+    #   - vLLM waiting-queue length (modelpod, gauge -> per-replica average)
+    #   - p95 request queue time     (modelpod, histogram -> quantile)
+    scaledobject.kaito.sh/metrics: |
+      - name: vllm:num_requests_waiting
+        type: gauge
+        upthreshold: 5
+        downthreshold: 1
+      - name: vllm:request_queue_time_seconds
+        type: histogram
+        upthreshold: 2.0
+        downthreshold: 0.5
+        quantile: 0.95
 
     # Optional global tuning (defaults shown)
     scaledobject.kaito.sh/combinepolicy: "AND"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.23.3
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -92,7 +93,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 // kedacore/keda/v2 v2.20.1 declares top-level requires for k8s.io/* v0.36.0 and

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,24 +27,14 @@ const (
 
 	// --- Auto-provision annotations ---
 
-	// AnnotationKeyMetricName is the base key for the indexed metric name
-	// (metricName/{i}). Presence of metricName/0 enables auto-provisioning.
-	AnnotationKeyMetricName = "scaledobject.kaito.sh/metricName"
+	// AnnotationKeyMetrics carries the auto-provision metrics as a YAML (or JSON)
+	// list. Each entry configures one metric with the fields: name, type,
+	// source (optional), upthreshold, downthreshold, and quantile (optional).
+	// A non-empty list (together with auto-provision="true") enables
+	// auto-provisioning.
+	AnnotationKeyMetrics = "scaledobject.kaito.sh/metrics"
 
-	// Per-metric keys, indexed with a "/{i}" suffix (e.g. metricstype/0, metricstype/1).
-
-	// AnnotationKeyMetricsType selects the metric aggregation: "gauge" or "histogram".
-	AnnotationKeyMetricsType = "scaledobject.kaito.sh/metricstype"
-	// AnnotationKeyMetricSource selects the metric source (default "modelpod").
-	AnnotationKeyMetricSource = "scaledobject.kaito.sh/metricsource"
-	// AnnotationKeyUpThreshold sets the per-metric scale-up threshold.
-	AnnotationKeyUpThreshold = "scaledobject.kaito.sh/upthreshold"
-	// AnnotationKeyDownThreshold sets the per-metric scale-down threshold.
-	AnnotationKeyDownThreshold = "scaledobject.kaito.sh/downthreshold"
-	// AnnotationKeyQuantile sets the target quantile for histogram metrics.
-	AnnotationKeyQuantile = "scaledobject.kaito.sh/quantile"
-
-	// Global keys (not indexed).
+	// Global keys.
 
 	// AnnotationKeyCombinePolicy selects how metrics are combined (only AND).
 	AnnotationKeyCombinePolicy = "scaledobject.kaito.sh/combinepolicy"

--- a/pkg/controllers/autoprovision/auto_provision_controller.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller.go
@@ -55,7 +55,7 @@ const (
 
 	// annotationPrefix is the common prefix for every autoscaling annotation the
 	// controller consumes on an InferenceSet. Any change to a key under this
-	// prefix (including the indexed composite keys) triggers a reconcile.
+	// prefix (including the metrics list annotation) triggers a reconcile.
 	annotationPrefix = "scaledobject.kaito.sh/"
 )
 
@@ -121,7 +121,7 @@ func (c *Controller) Reconcile(ctx context.Context, is *kaitov1beta1.InferenceSe
 	}
 
 	// Build the desired ScaledObject from the InferenceSet's auto-provision
-	// annotations (one or more indexed metrics combined under a conservative AND
+	// annotations (one or more metrics combined under a conservative AND
 	// policy).
 	soBuilder := scaledobject.Builder{
 		ScalerNamespace:   c.ScalerNamespace,
@@ -375,8 +375,8 @@ func generateInferenceSetPredicateFunc() predicate.Predicate {
 			}
 
 			// Reconcile when any autoscaling annotation changes. Comparing by
-			// prefix covers the fixed single-metric keys as well as the indexed
-			// composite keys (metricName/0, upthreshold/0, ...).
+			// prefix covers all scaledobject.kaito.sh/ keys, including the
+			// scaledobject.kaito.sh/metrics list annotation.
 			if annotationsWithPrefixChanged(oldInferenceSet.Annotations, newInferenceSet.Annotations, annotationPrefix) {
 				// Fire when the new state is validly enabled (provision/update) or
 				// the old state requested auto-provisioning (so toggling the

--- a/pkg/controllers/autoprovision/auto_provision_controller_test.go
+++ b/pkg/controllers/autoprovision/auto_provision_controller_test.go
@@ -205,16 +205,18 @@ func TestResolveMaxReplicas(t *testing.T) {
 // auto-provisioning.
 func compositeAnnotations() map[string]string {
 	return map[string]string{
-		constants.AnnotationKeyAutoProvision:    "true",
-		constants.AnnotationKeyMaxReplicas:      "5",
-		"scaledobject.kaito.sh/metricName/0":    "vllm:num_requests_waiting",
-		"scaledobject.kaito.sh/metricstype/0":   "gauge",
-		"scaledobject.kaito.sh/upthreshold/0":   "10",
-		"scaledobject.kaito.sh/downthreshold/0": "2",
-		"scaledobject.kaito.sh/metricName/1":    "vllm:request_queue_time_seconds",
-		"scaledobject.kaito.sh/metricstype/1":   "histogram",
-		"scaledobject.kaito.sh/upthreshold/1":   "1.5",
-		"scaledobject.kaito.sh/downthreshold/1": "0.5",
+		constants.AnnotationKeyAutoProvision: "true",
+		constants.AnnotationKeyMaxReplicas:   "5",
+		constants.AnnotationKeyMetrics: `
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: 10
+  downthreshold: 2
+- name: vllm:request_queue_time_seconds
+  type: histogram
+  upthreshold: 1.5
+  downthreshold: 0.5
+`,
 	}
 }
 
@@ -226,19 +228,26 @@ func TestAutoscalingConfigValid_Composite(t *testing.T) {
 
 	t.Run("invalid composite disabled", func(t *testing.T) {
 		ann := compositeAnnotations()
-		ann["scaledobject.kaito.sh/metricstype/0"] = "bogus"
+		ann[constants.AnnotationKeyMetrics] = `
+- name: vllm:num_requests_waiting
+  type: bogus
+  upthreshold: 10
+  downthreshold: 2
+`
 		is := &kaitov1beta1.InferenceSet{ObjectMeta: metav1.ObjectMeta{Annotations: ann}}
 		assert.False(t, autoscalingConfigValid(is))
 	})
 
 	t.Run("single metric config accepted", func(t *testing.T) {
 		is := &kaitov1beta1.InferenceSet{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
-			constants.AnnotationKeyAutoProvision:    "true",
-			constants.AnnotationKeyMaxReplicas:      "5",
-			"scaledobject.kaito.sh/metricName/0":    "vllm:num_requests_waiting",
-			"scaledobject.kaito.sh/metricstype/0":   "gauge",
-			"scaledobject.kaito.sh/upthreshold/0":   "5",
-			"scaledobject.kaito.sh/downthreshold/0": "1",
+			constants.AnnotationKeyAutoProvision: "true",
+			constants.AnnotationKeyMaxReplicas:   "5",
+			constants.AnnotationKeyMetrics: `
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: 5
+  downthreshold: 1
+`,
 		}}}
 		assert.True(t, autoscalingConfigValid(is))
 	})
@@ -253,18 +262,18 @@ func TestAutoscalingConfigValid_Composite(t *testing.T) {
 }
 
 func TestAnnotationsWithPrefixChanged(t *testing.T) {
-	old := map[string]string{"scaledobject.kaito.sh/metricName/0": "queue", "other": "x"}
+	old := map[string]string{"scaledobject.kaito.sh/metrics": "queue", "other": "x"}
 
-	// Changing an indexed composite key is detected.
-	next := map[string]string{"scaledobject.kaito.sh/metricName/0": "latency-p95", "other": "x"}
+	// Changing a composite key is detected.
+	next := map[string]string{"scaledobject.kaito.sh/metrics": "latency-p95", "other": "x"}
 	assert.True(t, annotationsWithPrefixChanged(old, next, annotationPrefix))
 
 	// Adding a new prefixed key is detected.
-	added := map[string]string{"scaledobject.kaito.sh/metricName/0": "queue", "scaledobject.kaito.sh/upthreshold/0": "10", "other": "x"}
+	added := map[string]string{"scaledobject.kaito.sh/metrics": "queue", "scaledobject.kaito.sh/max-replicas": "10", "other": "x"}
 	assert.True(t, annotationsWithPrefixChanged(old, added, annotationPrefix))
 
 	// Changing a non-prefixed key is ignored.
-	unrelated := map[string]string{"scaledobject.kaito.sh/metricName/0": "queue", "other": "y"}
+	unrelated := map[string]string{"scaledobject.kaito.sh/metrics": "queue", "other": "y"}
 	assert.False(t, annotationsWithPrefixChanged(old, unrelated, annotationPrefix))
 }
 

--- a/pkg/scaledobject/provisioner.go
+++ b/pkg/scaledobject/provisioner.go
@@ -12,11 +12,12 @@
 // limitations under the License.
 
 // Package scaledobject owns the InferenceSet autoscaling annotation schema and
-// builds the desired KEDA ScaledObject. Autoscaling is driven by one or more
-// indexed metric annotations (metricName/{i}, ...): configuring a single metric
-// yields a single-signal ScaledObject, configuring several combines them under a
-// conservative AND policy. The reconciler stays agnostic of how the ScaledObject
-// is assembled by delegating to Builder.BuildDesired.
+// builds the desired KEDA ScaledObject. Autoscaling is driven by the
+// scaledobject.kaito.sh/metrics annotation, a YAML list of metric entries:
+// configuring a single metric yields a single-signal ScaledObject, configuring
+// several combines them under a conservative AND policy. The reconciler stays
+// agnostic of how the ScaledObject is assembled by delegating to
+// Builder.BuildDesired.
 package scaledobject
 
 import (
@@ -31,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kaito-project/keda-kaito-scaler/pkg/aggregator"
 	"github.com/kaito-project/keda-kaito-scaler/pkg/constants"
@@ -219,15 +221,29 @@ func ValidateConfig(annotations map[string]string) error {
 	return err
 }
 
-// indexedKey builds an indexed annotation key such as
-// "scaledobject.kaito.sh/metricName/0".
-func indexedKey(base string, i int) string {
-	return fmt.Sprintf("%s/%d", base, i)
+// metricSpec is one entry of the scaledobject.kaito.sh/metrics annotation, a
+// YAML (or JSON) list. Threshold and quantile fields are pointers so a missing
+// key can be told apart from an explicit zero.
+type metricSpec struct {
+	// Name is the Prometheus metric name.
+	Name string `json:"name"`
+	// Type selects the aggregation: "gauge" or "histogram".
+	Type string `json:"type"`
+	// Source selects the metric source (optional, default "modelpod").
+	Source string `json:"source,omitempty"`
+	// UpThreshold is the scale-up threshold.
+	UpThreshold *float64 `json:"upthreshold"`
+	// DownThreshold is the scale-down threshold (must be <= upthreshold).
+	DownThreshold *float64 `json:"downthreshold"`
+	// Quantile is the target quantile in (0, 1] for histogram metrics (optional).
+	Quantile *float64 `json:"quantile,omitempty"`
 }
 
-// parseMetricsConfig parses and validates the auto-provision annotations
-// into a metricsConfig. It returns an error describing the first invalid or
-// missing field encountered.
+// parseMetricsConfig parses and validates the auto-provision annotations into a
+// metricsConfig. The per-metric configuration is read from the
+// scaledobject.kaito.sh/metrics annotation (a YAML list); the remaining global
+// settings come from their own annotations. It returns an error describing the
+// first invalid or missing field encountered.
 func parseMetricsConfig(annotations map[string]string) (metricsConfig, error) {
 	var cfg metricsConfig
 
@@ -243,45 +259,54 @@ func parseMetricsConfig(annotations map[string]string) (metricsConfig, error) {
 	}
 	cfg.policy = policy
 
+	// The per-metric configuration lives in a single YAML/JSON list annotation.
+	raw := annotations[constants.AnnotationKeyMetrics]
+	if strings.TrimSpace(raw) == "" {
+		return cfg, fmt.Errorf("auto-provision requires the %s annotation with at least one metric", constants.AnnotationKeyMetrics)
+	}
+	var specs []metricSpec
+	if err := yaml.Unmarshal([]byte(raw), &specs); err != nil {
+		return cfg, fmt.Errorf("invalid %s annotation: %w", constants.AnnotationKeyMetrics, err)
+	}
+	if len(specs) == 0 {
+		return cfg, fmt.Errorf("auto-provision requires the %s annotation with at least one metric", constants.AnnotationKeyMetrics)
+	}
+
 	seenVars := make(map[string]string)
-	for i := 0; ; i++ {
-		key := annotations[indexedKey(constants.AnnotationKeyMetricName, i)]
-		if key == "" {
-			break
+	for i, spec := range specs {
+		if spec.Name == "" {
+			return cfg, fmt.Errorf("metric index %d: name is required", i)
 		}
 
-		// metricstype is required and decides the aggregation; metricsource is
-		// optional and selects the metric source (default "modelpod").
-		aggregation, err := aggregationForMetricsType(annotations[indexedKey(constants.AnnotationKeyMetricsType, i)])
+		// type is required and decides the aggregation; source is optional and
+		// selects the metric source (default "modelpod").
+		aggregation, err := aggregationForMetricsType(spec.Type)
 		if err != nil {
-			return cfg, fmt.Errorf("metric %q (index %d): %w", key, i, err)
+			return cfg, fmt.Errorf("metric %q (index %d): %w", spec.Name, i, err)
 		}
-		source, err := sourceForMetricSource(annotations[indexedKey(constants.AnnotationKeyMetricSource, i)])
+		source, err := sourceForMetricSource(spec.Source)
 		if err != nil {
-			return cfg, fmt.Errorf("metric %q (index %d): %w", key, i, err)
+			return cfg, fmt.Errorf("metric %q (index %d): %w", spec.Name, i, err)
 		}
 
 		// The metric name doubles as the formula variable/trigger name after
 		// sanitization; two metrics collapsing to the same variable would make the
 		// formula ambiguous and KEDA reject duplicate trigger names.
-		varName := formulaVarName(key)
+		varName := formulaVarName(spec.Name)
 		if prev, dup := seenVars[varName]; dup {
-			return cfg, fmt.Errorf("metric %q (index %d) collides with %q on formula variable %q", key, i, prev, varName)
+			return cfg, fmt.Errorf("metric %q (index %d) collides with %q on formula variable %q", spec.Name, i, prev, varName)
 		}
-		seenVars[varName] = key
+		seenVars[varName] = spec.Name
 
-		upStr := annotations[indexedKey(constants.AnnotationKeyUpThreshold, i)]
-		downStr := annotations[indexedKey(constants.AnnotationKeyDownThreshold, i)]
-		up, err := strconv.ParseFloat(upStr, 64)
-		if err != nil || math.IsNaN(up) || math.IsInf(up, 0) {
-			return cfg, fmt.Errorf("metric %q (index %d): upthreshold must be a valid finite number, got %q", key, i, upStr)
+		if spec.UpThreshold == nil {
+			return cfg, fmt.Errorf("metric %q (index %d): upthreshold is required", spec.Name, i)
 		}
-		down, err := strconv.ParseFloat(downStr, 64)
-		if err != nil || math.IsNaN(down) || math.IsInf(down, 0) {
-			return cfg, fmt.Errorf("metric %q (index %d): downthreshold must be a valid finite number, got %q", key, i, downStr)
+		if spec.DownThreshold == nil {
+			return cfg, fmt.Errorf("metric %q (index %d): downthreshold is required", spec.Name, i)
 		}
+		up, down := *spec.UpThreshold, *spec.DownThreshold
 		if down > up {
-			return cfg, fmt.Errorf("metric %q (index %d): downthreshold (%s) must not exceed upthreshold (%s)", key, i, downStr, upStr)
+			return cfg, fmt.Errorf("metric %q (index %d): downthreshold (%s) must not exceed upthreshold (%s)", spec.Name, i, strconv.FormatFloat(down, 'f', -1, 64), strconv.FormatFloat(up, 'f', -1, 64))
 		}
 
 		// Quantile is only meaningful for histogram metrics (quantile aggregation);
@@ -289,30 +314,23 @@ func parseMetricsConfig(annotations map[string]string) (metricsConfig, error) {
 		quantile := ""
 		if aggregation == aggregator.QuantileAggregatorName {
 			quantile = defaultQuantile
-			if q := annotations[indexedKey(constants.AnnotationKeyQuantile, i)]; q != "" {
-				qv, err := strconv.ParseFloat(q, 64)
-				if err != nil {
-					return cfg, fmt.Errorf("metric %q (index %d): quantile must be a valid number, got %q", key, i, q)
-				}
-				if math.IsNaN(qv) || qv <= 0 || qv > 1 {
-					return cfg, fmt.Errorf("metric %q (index %d): quantile must be in the (0, 1] range, got %q", key, i, q)
+			if spec.Quantile != nil {
+				qv := *spec.Quantile
+				if qv <= 0 || qv > 1 {
+					return cfg, fmt.Errorf("metric %q (index %d): quantile must be in the (0, 1] range, got %s", spec.Name, i, strconv.FormatFloat(qv, 'f', -1, 64))
 				}
 				quantile = strconv.FormatFloat(qv, 'f', -1, 64)
 			}
 		}
 
 		cfg.metrics = append(cfg.metrics, metric{
-			key:           key,
+			key:           spec.Name,
 			source:        source,
 			aggregation:   aggregation,
 			upThreshold:   strconv.FormatFloat(up, 'f', -1, 64),
 			downThreshold: strconv.FormatFloat(down, 'f', -1, 64),
 			quantile:      quantile,
 		})
-	}
-
-	if len(cfg.metrics) == 0 {
-		return cfg, fmt.Errorf("auto-provision requires at least one metricName/0 annotation")
 	}
 
 	var err error

--- a/pkg/scaledobject/provisioner_test.go
+++ b/pkg/scaledobject/provisioner_test.go
@@ -14,6 +14,7 @@
 package scaledobject
 
 import (
+	"fmt"
 	"testing"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
@@ -24,18 +25,23 @@ import (
 	"github.com/kaito-project/keda-kaito-scaler/pkg/constants"
 )
 
+// metricsAnn wraps a metrics YAML list body into an annotation map.
+func metricsAnn(body string) map[string]string {
+	return map[string]string{constants.AnnotationKeyMetrics: body}
+}
+
 // metricsAnnotations returns a valid two-metric annotation set.
 func metricsAnnotations() map[string]string {
-	return map[string]string{
-		indexedKey(constants.AnnotationKeyMetricName, 0): "vllm:num_requests_waiting",
-		"scaledobject.kaito.sh/metricstype/0":            "gauge",
-		"scaledobject.kaito.sh/upthreshold/0":            "10",
-		"scaledobject.kaito.sh/downthreshold/0":          "2",
-		indexedKey(constants.AnnotationKeyMetricName, 1): "vllm:request_queue_time_seconds",
-		"scaledobject.kaito.sh/metricstype/1":            "histogram",
-		"scaledobject.kaito.sh/upthreshold/1":            "1.5",
-		"scaledobject.kaito.sh/downthreshold/1":          "0.5",
-	}
+	return metricsAnn(`
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: 10
+  downthreshold: 2
+- name: vllm:request_queue_time_seconds
+  type: histogram
+  upthreshold: 1.5
+  downthreshold: 0.5
+`)
 }
 
 func TestParseMetricsConfig(t *testing.T) {
@@ -59,12 +65,12 @@ func TestParseMetricsConfig(t *testing.T) {
 	})
 
 	t.Run("valid single-metric config", func(t *testing.T) {
-		ann := map[string]string{
-			indexedKey(constants.AnnotationKeyMetricName, 0): "vllm:num_requests_waiting",
-			"scaledobject.kaito.sh/metricstype/0":            "gauge",
-			"scaledobject.kaito.sh/upthreshold/0":            "5",
-			"scaledobject.kaito.sh/downthreshold/0":          "1",
-		}
+		ann := metricsAnn(`
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: 5
+  downthreshold: 1
+`)
 		cfg, err := parseMetricsConfig(ann)
 		assert.NoError(t, err)
 		assert.Len(t, cfg.metrics, 1)
@@ -84,57 +90,90 @@ func TestParseMetricsConfig(t *testing.T) {
 	})
 
 	t.Run("missing metricstype rejected", func(t *testing.T) {
-		ann := metricsAnnotations()
-		delete(ann, "scaledobject.kaito.sh/metricstype/0")
+		ann := metricsAnn(`
+- name: vllm:num_requests_waiting
+  upthreshold: 10
+  downthreshold: 2
+`)
 		_, err := parseMetricsConfig(ann)
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid metricstype rejected", func(t *testing.T) {
-		ann := metricsAnnotations()
-		ann["scaledobject.kaito.sh/metricstype/0"] = "bogus"
+		ann := metricsAnn(`
+- name: vllm:num_requests_waiting
+  type: bogus
+  upthreshold: 10
+  downthreshold: 2
+`)
 		_, err := parseMetricsConfig(ann)
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid metricsource rejected", func(t *testing.T) {
-		ann := metricsAnnotations()
-		ann["scaledobject.kaito.sh/metricsource/0"] = "bogus"
+		ann := metricsAnn(`
+- name: vllm:num_requests_waiting
+  type: gauge
+  source: bogus
+  upthreshold: 10
+  downthreshold: 2
+`)
 		_, err := parseMetricsConfig(ann)
 		assert.Error(t, err)
 	})
 
 	t.Run("invalid up threshold rejected", func(t *testing.T) {
-		ann := metricsAnnotations()
-		ann["scaledobject.kaito.sh/upthreshold/0"] = "abc"
+		ann := metricsAnn(`
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: abc
+  downthreshold: 2
+`)
 		_, err := parseMetricsConfig(ann)
 		assert.Error(t, err)
 	})
 
 	t.Run("non-finite thresholds rejected", func(t *testing.T) {
-		for _, v := range []string{"NaN", "Inf", "+Inf", "-Inf"} {
-			ann := metricsAnnotations()
-			ann["scaledobject.kaito.sh/upthreshold/0"] = v
+		for _, v := range []string{"NaN", ".inf", "+.inf", "-.inf"} {
+			ann := metricsAnn(fmt.Sprintf(`
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: %s
+  downthreshold: 2
+`, v))
 			_, err := parseMetricsConfig(ann)
 			assert.Error(t, err, "upthreshold %q", v)
 
-			ann = metricsAnnotations()
-			ann["scaledobject.kaito.sh/downthreshold/0"] = v
+			ann = metricsAnn(fmt.Sprintf(`
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: 2
+  downthreshold: %s
+`, v))
 			_, err = parseMetricsConfig(ann)
 			assert.Error(t, err, "downthreshold %q", v)
 		}
 	})
 
 	t.Run("down greater than up rejected", func(t *testing.T) {
-		ann := metricsAnnotations()
-		ann["scaledobject.kaito.sh/downthreshold/0"] = "20"
+		ann := metricsAnn(`
+- name: vllm:num_requests_waiting
+  type: gauge
+  upthreshold: 10
+  downthreshold: 20
+`)
 		_, err := parseMetricsConfig(ann)
 		assert.Error(t, err)
 	})
 
 	t.Run("NaN quantile rejected", func(t *testing.T) {
-		ann := metricsAnnotations()
-		ann[indexedKey(constants.AnnotationKeyQuantile, 1)] = "NaN"
+		ann := metricsAnn(`
+- name: vllm:request_queue_time_seconds
+  type: histogram
+  upthreshold: 1.5
+  downthreshold: 0.5
+  quantile: NaN
+`)
 		_, err := parseMetricsConfig(ann)
 		assert.Error(t, err)
 	})
@@ -154,7 +193,7 @@ func TestParseMetricsConfig(t *testing.T) {
 	})
 
 	t.Run("no metrics rejected", func(t *testing.T) {
-		_, err := parseMetricsConfig(map[string]string{"scaledobject.kaito.sh/auto-provision": "true"})
+		_, err := parseMetricsConfig(map[string]string{constants.AnnotationKeyAutoProvision: "true"})
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

The v0.6.0 indexed annotation keys (scaledobject.kaito.sh/metricName/0, ...) are invalid Kubernetes annotation keys: k8s allows only a single '/' separating the DNS-subdomain prefix from the name, so any InferenceSet using them is rejected by the apiserver (issue #128).

Replace the indexed per-metric keys with a single
scaledobject.kaito.sh/metrics annotation carrying a YAML/JSON list, one entry per metric (name, type, source, upthreshold, downthreshold, quantile). Global keys (combinepolicy, evaluationwindow, cooldowns) are unchanged. Validation semantics are preserved.

Updates constants, provisioner parsing (via sigs.k8s.io/yaml), controller comments, tests, and README examples.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Fixes #128 

**Notes for Reviewers**: