### PR TITLE
Upgrade to v0.6.1 and harden auto-provision metric validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for KEDA Kaito Scaler
 
 REGISTRY ?= YOUR_REGISTRY
-VERSION ?= v0.6.0
+VERSION ?= v0.6.1
 IMG_TAG ?= $(subst v,,$(VERSION))
 PROJECT_ROOT ?= $(shell pwd)
 OUTPUT_DIR := $(PROJECT_ROOT)/_output

--- a/charts/keda-kaito-scaler/Chart.yaml
+++ b/charts/keda-kaito-scaler/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.6.0"
+appVersion: "v0.6.1"

--- a/charts/keda-kaito-scaler/values.yaml
+++ b/charts/keda-kaito-scaler/values.yaml
@@ -8,7 +8,7 @@ nameOverrider: ""
 image:
     registry: ghcr.io
     repository: kaito-project/keda-kaito-scaler
-    tag: 0.6.0
+    tag: 0.6.1
     pullSecrets: []
 
 ports:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -27,11 +27,11 @@ const (
 
 	// --- Auto-provision annotations ---
 
-	// AnnotationKeyMetrics carries the auto-provision metrics as a YAML (or JSON)
-	// list. Each entry configures one metric with the fields: name, type,
+	// AnnotationKeyMetrics carries the auto-provision metrics as a YAML list.
+	// Each entry configures one metric with the fields: name, type,
 	// source (optional), upthreshold, downthreshold, and quantile (optional).
-	// A non-empty list (together with auto-provision="true") enables
-	// auto-provisioning.
+	// When auto-provision="true", this annotation is required and must contain
+	// at least one metric; otherwise auto-provisioning fails with an error.
 	AnnotationKeyMetrics = "scaledobject.kaito.sh/metrics"
 
 	// Global keys.

--- a/pkg/scaledobject/provisioner.go
+++ b/pkg/scaledobject/provisioner.go
@@ -186,7 +186,7 @@ func aggregationForMetricsType(t string) (string, error) {
 	case metricsTypeHistogram:
 		return aggregator.QuantileAggregatorName, nil
 	default:
-		return "", fmt.Errorf("metricstype must be %q or %q, got %q", metricsTypeGauge, metricsTypeHistogram, t)
+		return "", fmt.Errorf("type must be %q or %q, got %q", metricsTypeGauge, metricsTypeHistogram, t)
 	}
 }
 
@@ -199,7 +199,7 @@ func sourceForMetricSource(s string) (string, error) {
 	case metricsource.ModelPodSourceName:
 		return metricsource.ModelPodSourceName, nil
 	default:
-		return "", fmt.Errorf("metricsource must be %q, got %q", metricsource.ModelPodSourceName, s)
+		return "", fmt.Errorf("source must be %q, got %q", metricsource.ModelPodSourceName, s)
 	}
 }
 
@@ -305,6 +305,14 @@ func parseMetricsConfig(annotations map[string]string) (metricsConfig, error) {
 			return cfg, fmt.Errorf("metric %q (index %d): downthreshold is required", spec.Name, i)
 		}
 		up, down := *spec.UpThreshold, *spec.DownThreshold
+		// YAML values like ".inf"/".nan" decode to non-finite floats; reject them
+		// so they cannot break formula/trigger rendering downstream.
+		if math.IsInf(up, 0) || math.IsNaN(up) {
+			return cfg, fmt.Errorf("metric %q (index %d): upthreshold must be a finite number, got %s", spec.Name, i, strconv.FormatFloat(up, 'f', -1, 64))
+		}
+		if math.IsInf(down, 0) || math.IsNaN(down) {
+			return cfg, fmt.Errorf("metric %q (index %d): downthreshold must be a finite number, got %s", spec.Name, i, strconv.FormatFloat(down, 'f', -1, 64))
+		}
 		if down > up {
 			return cfg, fmt.Errorf("metric %q (index %d): downthreshold (%s) must not exceed upthreshold (%s)", spec.Name, i, strconv.FormatFloat(down, 'f', -1, 64), strconv.FormatFloat(up, 'f', -1, 64))
 		}
@@ -316,7 +324,7 @@ func parseMetricsConfig(annotations map[string]string) (metricsConfig, error) {
 			quantile = defaultQuantile
 			if spec.Quantile != nil {
 				qv := *spec.Quantile
-				if qv <= 0 || qv > 1 {
+				if math.IsNaN(qv) || math.IsInf(qv, 0) || qv <= 0 || qv > 1 {
 					return cfg, fmt.Errorf("metric %q (index %d): quantile must be in the (0, 1] range, got %s", spec.Name, i, strconv.FormatFloat(qv, 'f', -1, 64))
 				}
 				quantile = strconv.FormatFloat(qv, 'f', -1, 64)


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

- Bump chart version/appVersion, image tag, and Makefile VERSION to v0.6.1
- Clarify metrics annotation is YAML-only and required when auto-provision=true
- Reject non-finite up/down thresholds and NaN/Inf quantile values
- Use user-facing field names (type/source) in validation errors

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: